### PR TITLE
Bug fix - update management intents

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The main function is to back up configurations from Intune to a Git repositry fr
 
 The package can also be run standalone outside of a pipeline, or in one to only backup data. Since 1.0.4, configurations are also created if they cannot be found. This means this tool could be used in a tenant to tenant migration scenario as well.
 
+## Whats new in 1.0.5
+- Bug fix where the tool was not able to identify the correct value format on management intents when updating values
 ## Whats new in 1.0.4
 - Backup of assignments
 - Update of assignments on existing configurations

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 1.0.4
+version = 1.0.5
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/src/IntuneCD/update_managementIntents.py
+++ b/src/IntuneCD/update_managementIntents.py
@@ -89,7 +89,7 @@ def update(path,token,assignment=False):
                                 print("Updating Intent settings: " + repo_setting['definitionId'] + ", values changed:")
                                 print(*diff.items(), sep='\n')
                                 ## Create dict that we will use as the request json
-                                if repo_setting['@odata.type'] == '#microsoft.graph.deviceManagementComplexSettingInstance':
+                                if "value" not in repo_setting:
                                     type = "valueJson"
                                     value = repo_setting['valueJson']
                                 else:


### PR DESCRIPTION
When running an update in management intents that do not contain "value" and only "valueJson", the tool was not able to correctly detect this. This version includes a fix for this.