### PR TITLE
Version 1.0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ The main function is to back up configurations from Intune to a Git repositry fr
 
 The package can also be run standalone outside of a pipeline, or in one to only backup data. Since 1.0.4, configurations are also created if they cannot be found. This means this tool could be used in a tenant to tenant migration scenario as well.
 
+## Whats new in 1.0.9
+- Bug fix where the script exited with "local variable referenced before assignment" if a management intent does not exist
+- Added a new parameter to let you exclude assignments from backups. To exclude assignments from backup, you can now use `-e assignments` when running IntuneCD-startbackup.
+
 ## Whats new in 1.0.8
 Main focus for this release has been to improve the performance as large setups can take a while to backup/update. With these enhancements, I was able to cut the run time by 80% in most cases
 
@@ -42,10 +46,6 @@ Main focus for this release has been to improve the performance as large setups 
 - Added a new option to the documentation module, '-i', which lets you configure your own introduction that will be displayed at the top
 - Changed documentation to display a collapsible view of long strings, now you can see the whole script payload for example
 - Improved console output when changes are detected, instead of writing the full path to the key, old output: `Setting: 'PayloadContent'][0]['PayloadContent']['corp.sap.privileges']['Forced'][0]['mcx_preference_settings']['ReasonMinLength', New Value: 15, Old Value: 20`, new output: `Setting: 'ReasonMinLength', New Value: 15, Old Value: 20`
-## Whats new in 1.0.6
-- Added documentation module to create a markdown document with information from the backup files
-- Bug fix where only one assignment was included in the backup. The tool now successfully backup/updates all assignments and removes assignments that is no longer in the backup files
-- Filters are now included when updating assignments, if a filter has been added in DEV and it exists in PROD, it will be added to the configuration when using -u
 
 ## Install this package
 ```python

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 1.0.8
+version = 1.0.9
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/src/IntuneCD/backup_AppProtection.py
+++ b/src/IntuneCD/backup_AppProtection.py
@@ -25,7 +25,7 @@ from .graph_batch import batch_assignment, get_object_assignment
 endpoint = "https://graph.microsoft.com/beta/deviceAppManagement/managedAppPolicies"
 
 ## Get all App Protection policies and save them in specified path
-def savebackup(path, output, token):
+def savebackup(path, output, exclude, token):
     configpath = path+"/"+"App Protection/"
     data = makeapirequest(endpoint, token)
 
@@ -35,10 +35,11 @@ def savebackup(path, output, token):
     for profile in data['value']:
         if profile['@odata.type'] == "#microsoft.graph.targetedManagedAppConfiguration":
             continue
-
-        assignments = get_object_assignment(profile['id'],assignment_responses)
-        if assignments:
-            profile['assignments'] = assignments
+        
+        if "assignments" not in exclude:
+            assignments = get_object_assignment(profile['id'],assignment_responses)
+            if assignments:
+                profile['assignments'] = assignments
         
         remove_keys = {'id', 'createdDateTime', 'version',
                        'lastModifiedDateTime', 'deployedAppCount', 'isAssigned'}

--- a/src/IntuneCD/backup_appConfiguration.py
+++ b/src/IntuneCD/backup_appConfiguration.py
@@ -26,16 +26,17 @@ endpoint = "https://graph.microsoft.com/beta/deviceAppManagement/mobileAppConfig
 app_endpoint = "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps"
 
 ## Get all App Configuration policies and save them in specified path
-def savebackup(path, output, token):
+def savebackup(path, output, exclude, token):
     configpath = path+"/"+"App Configuration/"
     data = makeapirequest(endpoint, token)
 
     assignment_responses = batch_assignment(data,f'deviceAppManagement/mobileAppConfigurations/','/assignments',token)
 
     for profile in data['value']:
-        assignments = get_object_assignment(profile['id'],assignment_responses)
-        if assignments:
-            profile['assignments'] = assignments
+        if "assignments" not in exclude:
+            assignments = get_object_assignment(profile['id'],assignment_responses)
+            if assignments:
+                profile['assignments'] = assignments
             
         remove_keys = {'id', 'createdDateTime',
                        'version', 'lastModifiedDateTime'}

--- a/src/IntuneCD/backup_applications.py
+++ b/src/IntuneCD/backup_applications.py
@@ -37,7 +37,7 @@ def match (platform,input) -> bool:
         return False
 
 ## Get all applications and save them in specified path
-def savebackup(path,output,token):
+def savebackup(path,output,exclude,token):
     configpath = f'{path}/Applications/'
 
     data = makeapirequest(endpoint,token,q_param)
@@ -46,9 +46,11 @@ def savebackup(path,output,token):
     for app in data['value']:
         app_name = ""
         platform = ""
-        assignments = get_object_assignment(app['id'],assignment_responses)
-        if assignments:
-            app['assignments'] = assignments
+
+        if "assignments" not in exclude:
+            assignments = get_object_assignment(app['id'],assignment_responses)
+            if assignments:
+                app['assignments'] = assignments
 
         remove_keys={'id','createdDateTime','version','lastModifiedDateTime','description'}
         for k in remove_keys:

--- a/src/IntuneCD/backup_compliance.py
+++ b/src/IntuneCD/backup_compliance.py
@@ -25,7 +25,7 @@ from .graph_batch import batch_assignment, get_object_assignment
 endpoint = "https://graph.microsoft.com/beta/deviceManagement/deviceCompliancePolicies"
 
 ## Get all Compliance policies and save them in specified path
-def savebackup(path, output, token):
+def savebackup(path, output, exclude, token):
     configpath = path+"/"+"Compliance Policies/Policies/"
     q_param = {
         "$expand": "scheduledActionsForRule($expand=scheduledActionConfigurations)"}
@@ -36,9 +36,10 @@ def savebackup(path, output, token):
     for policy in data['value']:
         print("Backing up compliance policy: " + policy['displayName'])
 
-        assignments = get_object_assignment(policy['id'],assignment_responses)
-        if assignments:
-            policy['assignments'] = assignments
+        if "assignments" not in exclude:
+            assignments = get_object_assignment(policy['id'],assignment_responses)
+            if assignments:
+                policy['assignments'] = assignments
 
         remove_keys = {'id', 'createdDateTime', 'version', 'lastModifiedDateTime', '@odata.context',
                        'scheduledActionConfigurations@odata.context', 'scheduledActionsForRule@odata.context'}

--- a/src/IntuneCD/backup_configurationPolicies.py
+++ b/src/IntuneCD/backup_configurationPolicies.py
@@ -25,7 +25,7 @@ from .graph_batch import batch_assignment, get_object_assignment, batch_request,
 baseEndpoint = "https://graph.microsoft.com/beta/deviceManagement"
 
 ## Get all Configuration Policies and save them in specified path
-def savebackup(path, output, token):
+def savebackup(path, output, exclude, token):
     configpath = path+"/"+"Settings Catalog/"
     policies = makeapirequest(baseEndpoint + "/configurationPolicies", token)
     policy_ids = []
@@ -46,9 +46,10 @@ def savebackup(path, output, token):
         if settings:
             policy['settings'] = settings
 
-        assignments = get_object_assignment(policy['id'],assignment_responses)
-        if assignments:
-            policy['assignments'] = assignments
+        if "assignments" not in exclude:
+            assignments = get_object_assignment(policy['id'],assignment_responses)
+            if assignments:
+                policy['assignments'] = assignments
 
         remove_keys = {'id', 'createdDateTime',
                        'version', 'lastModifiedDateTime'}

--- a/src/IntuneCD/backup_managementIntents.py
+++ b/src/IntuneCD/backup_managementIntents.py
@@ -26,7 +26,7 @@ baseEndpoint = "https://graph.microsoft.com/beta/deviceManagement"
 template_endpoint = "https://graph.microsoft.com/beta/deviceManagement/templates"
 
 ## Get all Intents and save them in specified path
-def savebackup(path, output, token):
+def savebackup(path, output, exclude, token):
     configpath = path+"/"+"Management Intents/"
     intents = makeapirequest(baseEndpoint + "/intents", token)
     templates = makeapirequest(template_endpoint,token)
@@ -47,10 +47,10 @@ def savebackup(path, output, token):
             if os.path.exists(configpath) == False:
                 os.makedirs(configpath)
 
-            #get_batch_assignment(intent_value,assignment_responses)
-            assignments = get_object_assignment(intent_value['id'],assignment_responses)
-            if assignments:
-                intent_value['assignments'] = assignments
+            if "assignments" not in exclude:
+                assignments = get_object_assignment(intent_value['id'],assignment_responses)
+                if assignments:
+                    intent_value['assignments'] = assignments
 
             for setting in intent_value['settingsDelta']:
                 setting.pop('id',None)

--- a/src/IntuneCD/backup_powershellScripts.py
+++ b/src/IntuneCD/backup_powershellScripts.py
@@ -26,7 +26,7 @@ from .graph_batch import batch_assignment, get_object_assignment, batch_request
 endpoint = "https://graph.microsoft.com/beta/deviceManagement/deviceManagementScripts/"
 
 ## Get all Powershell scripts and save them in specified path
-def savebackup(path, output, token):
+def savebackup(path, output, exclude, token):
     configpath = path+"/"+"Scripts/Powershell/"
     data = makeapirequest(endpoint, token)
     script_ids = []
@@ -37,9 +37,10 @@ def savebackup(path, output, token):
     script_data_responses = batch_request(script_ids,f'deviceManagement/deviceManagementScripts/','',token)
 
     for script_data in script_data_responses:
-        assignments = get_object_assignment(script_data['id'],assignment_responses)
-        if assignments:
-            script_data['assignments'] = assignments
+        if "assignments" not in exclude:
+            assignments = get_object_assignment(script_data['id'],assignment_responses)
+            if assignments:
+                script_data['assignments'] = assignments
 
         remove_keys = {'id', 'createdDateTime',
                        'version', 'lastModifiedDateTime'}

--- a/src/IntuneCD/backup_proactiveRemediation.py
+++ b/src/IntuneCD/backup_proactiveRemediation.py
@@ -26,7 +26,7 @@ from .graph_batch import batch_assignment, get_object_assignment, batch_request
 endpoint = "https://graph.microsoft.com/beta/deviceManagement/deviceHealthScripts"
 
 ## Get all Proactive Remediations and save them in specified path
-def savebackup(path, output, token):
+def savebackup(path, output, exclude, token):
     configpath = f'{path}/Proactive Remediations/'
     data = makeapirequest(endpoint, token)
     pr_ids = []
@@ -39,9 +39,10 @@ def savebackup(path, output, token):
     for pr_details in pr_data_responses:
         if "Microsoft" not in pr_details['publisher']:
             
-            assignments = get_object_assignment(pr_details['id'],assignment_responses)
-            if assignments:
-                pr_details['assignments'] = assignments
+            if "assignments" not in exclude:
+                assignments = get_object_assignment(pr_details['id'],assignment_responses)
+                if assignments:
+                    pr_details['assignments'] = assignments
                 
             remove_keys = {'id', 'createdDateTime', 'version',
                            'lastModifiedDateTime', 'isGlobalScript', 'highestAvailableVersion'}

--- a/src/IntuneCD/backup_profiles.py
+++ b/src/IntuneCD/backup_profiles.py
@@ -36,7 +36,7 @@ def match (platform,input) -> bool:
         return False
 
 ## Get all Device Configurations and save them in specified path
-def savebackup(path, output, token):
+def savebackup(path, output, exclude, token):
 
     configpath = path+"/"+"Device Configurations/"
     data = makeapirequest(endpoint, token)
@@ -44,10 +44,10 @@ def savebackup(path, output, token):
     assignment_responses = batch_assignment(data,f'deviceManagement/deviceConfigurations/','/assignments',token)
 
     for profile in data['value']:
-        #get_batch_assignment(profile,assignment_responses)
-        assignments = get_object_assignment(profile['id'],assignment_responses)
-        if assignments:
-            profile['assignments'] = assignments   
+        if "assignments" not in exclude:
+            assignments = get_object_assignment(profile['id'],assignment_responses)
+            if assignments:
+                profile['assignments'] = assignments   
 
         pid = profile['id']
         remove_keys = {'id', 'createdDateTime', 'version',

--- a/src/IntuneCD/backup_shellScripts.py
+++ b/src/IntuneCD/backup_shellScripts.py
@@ -27,7 +27,7 @@ endpoint = "https://graph.microsoft.com/beta/deviceManagement/deviceShellScripts
 assignment_endpoint = "https://graph.microsoft.com/beta/deviceManagement/deviceManagementScripts"
 
 ## Get all Shell scripts and save them in specified path
-def savebackup(path, output, token):
+def savebackup(path, output, exclude, token):
     configpath = path+"/"+"Scripts/Shell/"
     data = makeapirequest(endpoint, token)
     script_ids = []
@@ -38,9 +38,10 @@ def savebackup(path, output, token):
     script_data_responses = batch_request(script_ids,f'deviceManagement/deviceShellScripts/','',token)
 
     for script_data in script_data_responses:
-        assignments = get_object_assignment(script_data['id'],assignment_responses)
-        if assignments:
-            script_data['assignments'] = assignments
+        if "assignments" not in exclude:
+            assignments = get_object_assignment(script_data['id'],assignment_responses)
+            if assignments:
+                script_data['assignments'] = assignments
 
         remove_keys = {'id', 'createdDateTime',
                        'version', 'lastModifiedDateTime'}

--- a/src/IntuneCD/backup_windowsEnrollmentProfile.py
+++ b/src/IntuneCD/backup_windowsEnrollmentProfile.py
@@ -25,16 +25,17 @@ from .graph_batch import batch_assignment,get_object_assignment
 endpoint = "https://graph.microsoft.com/beta/deviceManagement/windowsAutopilotDeploymentProfiles"
 
 ## Get all Windows Enrollment Profiles and save them in specified path
-def savebackup(path, output, token):
+def savebackup(path, output, exclude, token):
     configpath = path+"/"+"Enrollment Profiles/Windows/"
     data = makeapirequest(endpoint, token)
 
     assignment_responses = batch_assignment(data,'deviceManagement/windowsAutopilotDeploymentProfiles/','/assignments',token)
 
     for profile in data['value']:
-        assignments = get_object_assignment(profile['id'],assignment_responses)
-        if assignments:
-            profile['assignments'] = assignments
+        if "assignments" not in exclude:
+            assignments = get_object_assignment(profile['id'],assignment_responses)
+            if assignments:
+                profile['assignments'] = assignments
         
         remove_keys = {'id', 'createdDateTime',
                        'version', 'lastModifiedDateTime'}

--- a/src/IntuneCD/graph_batch.py
+++ b/src/IntuneCD/graph_batch.py
@@ -151,6 +151,8 @@ def batch_intents(data, token) -> dict:
     base_url = 'deviceManagement'
     template_ids = []
     settings_id = []
+    categories_responses = []
+    settings_responses = []
     intent_values = {'value': []}
 
     ## Get each template ID

--- a/src/IntuneCD/run_backup.py
+++ b/src/IntuneCD/run_backup.py
@@ -37,6 +37,11 @@ def start():
                 "params:DEV_TENANT_NAME, DEV_CLIENT_ID, DEV_CLIENT_SECRET when run in devtoprod"),
         type=str
     )
+    parser.add_option(
+        "-e", "--exclude",
+        help = "List of objects to exclude from the backup, separated by commas. Currently supported objects are: assignments",
+        type = str
+    )
 
     (opts, _) = parser.parse_args()
 
@@ -57,13 +62,13 @@ def start():
 
     token = getAuth(selected_mode(opts.mode),opts.localauth,tenant="DEV")
 
-    def run_backup(path,output,token):
+    def run_backup(path,output,exclude,token):
 
         from .backup_appConfiguration import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
         from .backup_AppProtection import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
         from .backup_apns import savebackup
         savebackup(path,output,token)
@@ -72,22 +77,22 @@ def start():
         savebackup(path,output,token)
 
         from .backup_applications import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
         from .backup_compliance import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
         from .backup_notificationTemplate import savebackup
         savebackup(path,output,token)
 
         from .backup_profiles import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
         from .backup_appleEnrollmentProfile import savebackup
         savebackup(path,output,token)
 
         from .backup_windowsEnrollmentProfile import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
         from .backup_assignmentFilters import savebackup
         savebackup(path,output,token)
@@ -96,7 +101,7 @@ def start():
         savebackup(path,output,token)
 
         from .backup_managementIntents import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
         from .backup_compliancePartner import savebackup
         savebackup(path,output,token)
@@ -108,23 +113,27 @@ def start():
         savebackup(path,output,token)
 
         from .backup_proactiveRemediation import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
         from .backup_powershellScripts import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
         from .backup_shellScripts import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
         from .backup_configurationPolicies import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
 
     if opts.output == 'json' or opts.output == 'yaml':
         if token is None:
             raise Exception("Token is empty, please check os.environ variables")
         else:
-            run_backup(opts.path,opts.output,token)
+            if opts.exclude:
+                exclude = opts.exclude.split(",")
+            else:
+                exclude = []
+            run_backup(opts.path,opts.output,exclude,token)
 
     else:
         print('Please enter a valid output format, json or yaml') 


### PR DESCRIPTION
- Bug fix where the script exited with "local variable referenced before assignment" if a management intent does not exist
- Added a new parameter to let you exclude assignments from backups. To exclude assignments from backup, you can now use `-e assignments` when running IntuneCD-startbackup.

Closes #29
Closes #30 
Closes #28 