### PR TITLE
Version 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ The main function is to back up configurations from Intune to a Git repositry fr
 
 The package can also be run standalone outside of a pipeline, or in one to only backup data. Since 1.0.4, configurations are also created if they cannot be found. This means this tool could be used in a tenant to tenant migration scenario as well.
 
+## Whats new in 1.1.0
+- Bug fix for App Protection policies not being able to be created in a tenant to tenant scenario
+- Bug fix for Configuration Profiles not being able to update assignment in a tenant to tenant scenario
+- Bug fix for Windows Autopilot profiles not being able to update assignment in a tenant to tenant scenario
+- Bug fix for assignment updates where updating assignments when creating new configurations were not possible if the group does not exist
+
 ## Whats new in 1.0.9
 - Bug fix where the script exited with "local variable referenced before assignment" if a management intent does not exist
 - Added a new parameter to let you exclude assignments from backups. To exclude assignments from backup, you can now use `-e assignments` when running IntuneCD-startbackup.
@@ -35,17 +41,6 @@ Main focus for this release has been to improve the performance as large setups 
 - Assignments are now batched using the new batching module
 - If 504 or 502 is encounterd while getting configurations, the tool will now try again to get the configuration
 - For Windows apps in documentation, detection scripts etc will now have a "Click to expand..." instead of showing the whole script
-
-## Whats new in 1.0.7
-- Added backup and documentation of Apple Push Notification configuration
-- Added backup and documentation of Apple Volume Purchase Program tokens
-- Added backup and documentation of Applications
-- Added backup and documentation of Managed Google Play Configuration
-- Added backup and documentation of Partner Connections (Compliance, Management and Remote Assistance)
-- Added backup, documentation and update module for Proactive Remediations
-- Added a new option to the documentation module, '-i', which lets you configure your own introduction that will be displayed at the top
-- Changed documentation to display a collapsible view of long strings, now you can see the whole script payload for example
-- Improved console output when changes are detected, instead of writing the full path to the key, old output: `Setting: 'PayloadContent'][0]['PayloadContent']['corp.sap.privileges']['Forced'][0]['mcx_preference_settings']['ReasonMinLength', New Value: 15, Old Value: 20`, new output: `Setting: 'ReasonMinLength', New Value: 15, Old Value: 20`
 
 ## Install this package
 ```python

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 1.0.9
+version = 1.1.0
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/src/IntuneCD/update_appProtection.py
+++ b/src/IntuneCD/update_appProtection.py
@@ -56,6 +56,14 @@ def update(path, token, assignment=False):
                         f = open(file)
                         repo_data = json.load(f)
 
+                    if repo_data:
+                        if repo_data['@odata.type'] == "#microsoft.graph.mdmWindowsInformationProtectionPolicy":
+                            platform = "mdmWindowsInformationProtectionPolicies"
+                        elif repo_data['@odata.type'] == "#microsoft.graph.windowsInformationProtectionPolicy":
+                            platform = "windowsInformationProtectionPolicies"
+                        else:
+                            platform = f"{str(repo_data['@odata.type']).split('.')[2]}s"
+
                     ## Create object to pass in to assignment function
                     assign_obj = {}
                     if "assignments" in repo_data:
@@ -82,13 +90,6 @@ def update(path, token, assignment=False):
                         remove_keys = {'id', 'createdDateTime','version','lastModifiedDateTime'}
                         for k in remove_keys:
                             data['value'].pop(k, None)
-
-                        if repo_data['@odata.type'] == "#microsoft.graph.mdmWindowsInformationProtectionPolicy":
-                            platform = "mdmWindowsInformationProtectionPolicies"
-                        elif repo_data['@odata.type'] == "#microsoft.graph.windowsInformationProtectionPolicy":
-                            platform = "windowsInformationProtectionPolicies"
-                        else:
-                            platform = f"{str(repo_data['@odata.type']).split('.')[2]}s"
 
                         diff = DeepDiff(data['value'], repo_data, ignore_order=True).get('values_changed', {})
 

--- a/src/IntuneCD/update_assignment.py
+++ b/src/IntuneCD/update_assignment.py
@@ -69,6 +69,7 @@ def update_assignment(repo,mem,token) -> list:
 
     diff = DeepDiff(mem,repo,ignore_order=True)
     added = diff.get('iterable_item_added', {})
+    update = False
 
     if diff:
         for val in repo:
@@ -91,16 +92,22 @@ def update_assignment(repo,mem,token) -> list:
                 if val['target']['deviceAndAppManagementAssignmentFilterId'] is None:
                     val['target'].pop('deviceAndAppManagementAssignmentFilterId')
                     val['target'].pop('deviceAndAppManagementAssignmentFilterType')
-                    
-        ## Print added assignments
-        if added:
-            print('Updating assignments, added assignments:')
-            updates = get_added_removed(added)
-            for update in updates:
-                print(update)
-            return repo
-        else:
-            return None
+
+        for val in repo:
+            if 'groupId' in val['target'] or '#microsoft.graph.allDevicesAssignmentTarget' in val['target']['@odata.type'] \
+            or '#microsoft.graph.allLicensedUsersAssignmentTarget' in val['target']['@odata.type']:
+                update = True
+
+        if update is True:
+            ## Print added assignments
+            if added:
+                print('Updating assignments, added assignments:')
+                updates = get_added_removed(added)
+                for update in updates:
+                    print(update)
+                return repo
+            else:
+                return None
 
 def post_assignment_update(object,id,url,extra_url,token,status_code=200):
     request_json = json.dumps(object)

--- a/src/IntuneCD/update_profiles.py
+++ b/src/IntuneCD/update_profiles.py
@@ -252,6 +252,6 @@ def update(path, token, assignment=False):
                         assignment = update_assignment(assign_obj,mem_assign_obj,token)
                         if assignment is not None:
                             request_data = {}
-                            request_data['deviceHealthScriptAssignments'] = assignment
+                            request_data['assignments'] = assignment
                             post_assignment_update(request_data,post_request['id'],'deviceManagement/deviceConfigurations','assign',token)
                         print("Profile created with id: " + post_request['id'])

--- a/src/IntuneCD/update_windowsEnrollmentProfile.py
+++ b/src/IntuneCD/update_windowsEnrollmentProfile.py
@@ -118,6 +118,6 @@ def update(path, token, assignment=False):
                         assignment = update_assignment(assign_obj,mem_assign_obj,token)
                         if assignment is not None:
                             request_data = {}
-                            request_data['target'] = assignment
-                            post_assignment_update(request_data,post_request['id'],'deviceManagement/windowsAutopilotDeploymentProfiles','assign',token,status_code=201)
+                            request_data['target'] = assignment[0]['target']
+                            post_assignment_update(request_data,post_request['id'],'deviceManagement/windowsAutopilotDeploymentProfiles','assignments',token,status_code=201)
                         print("Autopilot profile created with id: " + post_request['id'])


### PR DESCRIPTION
- Bug fix for App Protection policies not being able to be created in a tenant to tenant scenario
- Bug fix for Configuration Profiles not being able to update assignment in a tenant to tenant scenario
- Bug fix for Windows Autopilot profiles not being able to update assignment in a tenant to tenant scenario
- Bug fix for assignment updates where updating assignments when creating new configurations were not possible if the group does not exist