### PR TITLE
Version 1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The main function is to back up configurations from Intune to a Git repositry fr
 The package can also be run standalone outside of a pipeline, or in one to only backup data. Since 1.0.4, configurations are also created if they cannot be found. This means this tool could be used in a tenant to tenant migration scenario as well.
 
 ## Whats new in 1.0.8
-Main focus for this release has been to improve the performance as large setups can take a while to backup/update. With these enhancements, I was able to cut the rumtime by 80% in most cases
+Main focus for this release has been to improve the performance as large setups can take a while to backup/update. With these enhancements, I was able to cut the run time by 80% in most cases
 
 - Added module to use MS Graph batching to get assignments instead on getting them for each configuration individually
 - General code clean up

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ The main function is to back up configurations from Intune to a Git repositry fr
 
 The package can also be run standalone outside of a pipeline, or in one to only backup data. Since 1.0.4, configurations are also created if they cannot be found. This means this tool could be used in a tenant to tenant migration scenario as well.
 
+## Whats new in 1.0.9
+- Bug fix where the script exited with "local variable referenced before assignment" if a management intent does not exist
+- Added a new parameter to let you exclude assignments from backups. To exclude assignments from backup, you can now use `-e assignments` when running IntuneCD-startbackup.
+
 ## Whats new in 1.0.8
 Main focus for this release has been to improve the performance as large setups can take a while to backup/update. With these enhancements, I was able to cut the run time by 80% in most cases
 
@@ -42,10 +46,6 @@ Main focus for this release has been to improve the performance as large setups 
 - Added a new option to the documentation module, '-i', which lets you configure your own introduction that will be displayed at the top
 - Changed documentation to display a collapsible view of long strings, now you can see the whole script payload for example
 - Improved console output when changes are detected, instead of writing the full path to the key, old output: `Setting: 'PayloadContent'][0]['PayloadContent']['corp.sap.privileges']['Forced'][0]['mcx_preference_settings']['ReasonMinLength', New Value: 15, Old Value: 20`, new output: `Setting: 'ReasonMinLength', New Value: 15, Old Value: 20`
-## Whats new in 1.0.6
-- Added documentation module to create a markdown document with information from the backup files
-- Bug fix where only one assignment was included in the backup. The tool now successfully backup/updates all assignments and removes assignments that is no longer in the backup files
-- Filters are now included when updating assignments, if a filter has been added in DEV and it exists in PROD, it will be added to the configuration when using -u
 
 ## Install this package
 ```python

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ The main function is to back up configurations from Intune to a Git repositry fr
 
 The package can also be run standalone outside of a pipeline, or in one to only backup data. Since 1.0.4, configurations are also created if they cannot be found. This means this tool could be used in a tenant to tenant migration scenario as well.
 
+## Whats new in 1.1.0
+- Bug fix for App Protection policies not being able to be created in a tenant to tenant scenario
+- Bug fix for Configuration Profiles not being able to update assignment in a tenant to tenant scenario
+- Bug fix for Windows Autopilot profiles not being able to update assignment in a tenant to tenant scenario
+- Bug fix for assignment updates where updating assignments when creating new configurations were not possible if the group does not exist
+
 ## Whats new in 1.0.9
 - Bug fix where the script exited with "local variable referenced before assignment" if a management intent does not exist
 - Added a new parameter to let you exclude assignments from backups. To exclude assignments from backup, you can now use `-e assignments` when running IntuneCD-startbackup.
@@ -35,17 +41,6 @@ Main focus for this release has been to improve the performance as large setups 
 - Assignments are now batched using the new batching module
 - If 504 or 502 is encounterd while getting configurations, the tool will now try again to get the configuration
 - For Windows apps in documentation, detection scripts etc will now have a "Click to expand..." instead of showing the whole script
-
-## Whats new in 1.0.7
-- Added backup and documentation of Apple Push Notification configuration
-- Added backup and documentation of Apple Volume Purchase Program tokens
-- Added backup and documentation of Applications
-- Added backup and documentation of Managed Google Play Configuration
-- Added backup and documentation of Partner Connections (Compliance, Management and Remote Assistance)
-- Added backup, documentation and update module for Proactive Remediations
-- Added a new option to the documentation module, '-i', which lets you configure your own introduction that will be displayed at the top
-- Changed documentation to display a collapsible view of long strings, now you can see the whole script payload for example
-- Improved console output when changes are detected, instead of writing the full path to the key, old output: `Setting: 'PayloadContent'][0]['PayloadContent']['corp.sap.privileges']['Forced'][0]['mcx_preference_settings']['ReasonMinLength', New Value: 15, Old Value: 20`, new output: `Setting: 'ReasonMinLength', New Value: 15, Old Value: 20`
 
 ## Install this package
 ```python

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 1.0.8
+version = 1.0.9
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 1.0.9
+version = 1.1.0
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/src/IntuneCD/backup_AppProtection.py
+++ b/src/IntuneCD/backup_AppProtection.py
@@ -25,7 +25,7 @@ from .graph_batch import batch_assignment, get_object_assignment
 endpoint = "https://graph.microsoft.com/beta/deviceAppManagement/managedAppPolicies"
 
 ## Get all App Protection policies and save them in specified path
-def savebackup(path, output, token):
+def savebackup(path, output, exclude, token):
     configpath = path+"/"+"App Protection/"
     data = makeapirequest(endpoint, token)
 
@@ -35,10 +35,11 @@ def savebackup(path, output, token):
     for profile in data['value']:
         if profile['@odata.type'] == "#microsoft.graph.targetedManagedAppConfiguration":
             continue
-
-        assignments = get_object_assignment(profile['id'],assignment_responses)
-        if assignments:
-            profile['assignments'] = assignments
+        
+        if "assignments" not in exclude:
+            assignments = get_object_assignment(profile['id'],assignment_responses)
+            if assignments:
+                profile['assignments'] = assignments
         
         remove_keys = {'id', 'createdDateTime', 'version',
                        'lastModifiedDateTime', 'deployedAppCount', 'isAssigned'}

--- a/src/IntuneCD/backup_appConfiguration.py
+++ b/src/IntuneCD/backup_appConfiguration.py
@@ -26,16 +26,17 @@ endpoint = "https://graph.microsoft.com/beta/deviceAppManagement/mobileAppConfig
 app_endpoint = "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps"
 
 ## Get all App Configuration policies and save them in specified path
-def savebackup(path, output, token):
+def savebackup(path, output, exclude, token):
     configpath = path+"/"+"App Configuration/"
     data = makeapirequest(endpoint, token)
 
     assignment_responses = batch_assignment(data,f'deviceAppManagement/mobileAppConfigurations/','/assignments',token)
 
     for profile in data['value']:
-        assignments = get_object_assignment(profile['id'],assignment_responses)
-        if assignments:
-            profile['assignments'] = assignments
+        if "assignments" not in exclude:
+            assignments = get_object_assignment(profile['id'],assignment_responses)
+            if assignments:
+                profile['assignments'] = assignments
             
         remove_keys = {'id', 'createdDateTime',
                        'version', 'lastModifiedDateTime'}

--- a/src/IntuneCD/backup_applications.py
+++ b/src/IntuneCD/backup_applications.py
@@ -37,7 +37,7 @@ def match (platform,input) -> bool:
         return False
 
 ## Get all applications and save them in specified path
-def savebackup(path,output,token):
+def savebackup(path,output,exclude,token):
     configpath = f'{path}/Applications/'
 
     data = makeapirequest(endpoint,token,q_param)
@@ -46,9 +46,11 @@ def savebackup(path,output,token):
     for app in data['value']:
         app_name = ""
         platform = ""
-        assignments = get_object_assignment(app['id'],assignment_responses)
-        if assignments:
-            app['assignments'] = assignments
+
+        if "assignments" not in exclude:
+            assignments = get_object_assignment(app['id'],assignment_responses)
+            if assignments:
+                app['assignments'] = assignments
 
         remove_keys={'id','createdDateTime','version','lastModifiedDateTime','description'}
         for k in remove_keys:

--- a/src/IntuneCD/backup_compliance.py
+++ b/src/IntuneCD/backup_compliance.py
@@ -25,7 +25,7 @@ from .graph_batch import batch_assignment, get_object_assignment
 endpoint = "https://graph.microsoft.com/beta/deviceManagement/deviceCompliancePolicies"
 
 ## Get all Compliance policies and save them in specified path
-def savebackup(path, output, token):
+def savebackup(path, output, exclude, token):
     configpath = path+"/"+"Compliance Policies/Policies/"
     q_param = {
         "$expand": "scheduledActionsForRule($expand=scheduledActionConfigurations)"}
@@ -36,9 +36,10 @@ def savebackup(path, output, token):
     for policy in data['value']:
         print("Backing up compliance policy: " + policy['displayName'])
 
-        assignments = get_object_assignment(policy['id'],assignment_responses)
-        if assignments:
-            policy['assignments'] = assignments
+        if "assignments" not in exclude:
+            assignments = get_object_assignment(policy['id'],assignment_responses)
+            if assignments:
+                policy['assignments'] = assignments
 
         remove_keys = {'id', 'createdDateTime', 'version', 'lastModifiedDateTime', '@odata.context',
                        'scheduledActionConfigurations@odata.context', 'scheduledActionsForRule@odata.context'}

--- a/src/IntuneCD/backup_configurationPolicies.py
+++ b/src/IntuneCD/backup_configurationPolicies.py
@@ -25,7 +25,7 @@ from .graph_batch import batch_assignment, get_object_assignment, batch_request,
 baseEndpoint = "https://graph.microsoft.com/beta/deviceManagement"
 
 ## Get all Configuration Policies and save them in specified path
-def savebackup(path, output, token):
+def savebackup(path, output, exclude, token):
     configpath = path+"/"+"Settings Catalog/"
     policies = makeapirequest(baseEndpoint + "/configurationPolicies", token)
     policy_ids = []
@@ -46,9 +46,10 @@ def savebackup(path, output, token):
         if settings:
             policy['settings'] = settings
 
-        assignments = get_object_assignment(policy['id'],assignment_responses)
-        if assignments:
-            policy['assignments'] = assignments
+        if "assignments" not in exclude:
+            assignments = get_object_assignment(policy['id'],assignment_responses)
+            if assignments:
+                policy['assignments'] = assignments
 
         remove_keys = {'id', 'createdDateTime',
                        'version', 'lastModifiedDateTime'}

--- a/src/IntuneCD/backup_managementIntents.py
+++ b/src/IntuneCD/backup_managementIntents.py
@@ -26,7 +26,7 @@ baseEndpoint = "https://graph.microsoft.com/beta/deviceManagement"
 template_endpoint = "https://graph.microsoft.com/beta/deviceManagement/templates"
 
 ## Get all Intents and save them in specified path
-def savebackup(path, output, token):
+def savebackup(path, output, exclude, token):
     configpath = path+"/"+"Management Intents/"
     intents = makeapirequest(baseEndpoint + "/intents", token)
     templates = makeapirequest(template_endpoint,token)
@@ -47,10 +47,10 @@ def savebackup(path, output, token):
             if os.path.exists(configpath) == False:
                 os.makedirs(configpath)
 
-            #get_batch_assignment(intent_value,assignment_responses)
-            assignments = get_object_assignment(intent_value['id'],assignment_responses)
-            if assignments:
-                intent_value['assignments'] = assignments
+            if "assignments" not in exclude:
+                assignments = get_object_assignment(intent_value['id'],assignment_responses)
+                if assignments:
+                    intent_value['assignments'] = assignments
 
             for setting in intent_value['settingsDelta']:
                 setting.pop('id',None)

--- a/src/IntuneCD/backup_powershellScripts.py
+++ b/src/IntuneCD/backup_powershellScripts.py
@@ -26,7 +26,7 @@ from .graph_batch import batch_assignment, get_object_assignment, batch_request
 endpoint = "https://graph.microsoft.com/beta/deviceManagement/deviceManagementScripts/"
 
 ## Get all Powershell scripts and save them in specified path
-def savebackup(path, output, token):
+def savebackup(path, output, exclude, token):
     configpath = path+"/"+"Scripts/Powershell/"
     data = makeapirequest(endpoint, token)
     script_ids = []
@@ -37,9 +37,10 @@ def savebackup(path, output, token):
     script_data_responses = batch_request(script_ids,f'deviceManagement/deviceManagementScripts/','',token)
 
     for script_data in script_data_responses:
-        assignments = get_object_assignment(script_data['id'],assignment_responses)
-        if assignments:
-            script_data['assignments'] = assignments
+        if "assignments" not in exclude:
+            assignments = get_object_assignment(script_data['id'],assignment_responses)
+            if assignments:
+                script_data['assignments'] = assignments
 
         remove_keys = {'id', 'createdDateTime',
                        'version', 'lastModifiedDateTime'}

--- a/src/IntuneCD/backup_proactiveRemediation.py
+++ b/src/IntuneCD/backup_proactiveRemediation.py
@@ -26,7 +26,7 @@ from .graph_batch import batch_assignment, get_object_assignment, batch_request
 endpoint = "https://graph.microsoft.com/beta/deviceManagement/deviceHealthScripts"
 
 ## Get all Proactive Remediations and save them in specified path
-def savebackup(path, output, token):
+def savebackup(path, output, exclude, token):
     configpath = f'{path}/Proactive Remediations/'
     data = makeapirequest(endpoint, token)
     pr_ids = []
@@ -39,9 +39,10 @@ def savebackup(path, output, token):
     for pr_details in pr_data_responses:
         if "Microsoft" not in pr_details['publisher']:
             
-            assignments = get_object_assignment(pr_details['id'],assignment_responses)
-            if assignments:
-                pr_details['assignments'] = assignments
+            if "assignments" not in exclude:
+                assignments = get_object_assignment(pr_details['id'],assignment_responses)
+                if assignments:
+                    pr_details['assignments'] = assignments
                 
             remove_keys = {'id', 'createdDateTime', 'version',
                            'lastModifiedDateTime', 'isGlobalScript', 'highestAvailableVersion'}

--- a/src/IntuneCD/backup_profiles.py
+++ b/src/IntuneCD/backup_profiles.py
@@ -36,7 +36,7 @@ def match (platform,input) -> bool:
         return False
 
 ## Get all Device Configurations and save them in specified path
-def savebackup(path, output, token):
+def savebackup(path, output, exclude, token):
 
     configpath = path+"/"+"Device Configurations/"
     data = makeapirequest(endpoint, token)
@@ -44,10 +44,10 @@ def savebackup(path, output, token):
     assignment_responses = batch_assignment(data,f'deviceManagement/deviceConfigurations/','/assignments',token)
 
     for profile in data['value']:
-        #get_batch_assignment(profile,assignment_responses)
-        assignments = get_object_assignment(profile['id'],assignment_responses)
-        if assignments:
-            profile['assignments'] = assignments   
+        if "assignments" not in exclude:
+            assignments = get_object_assignment(profile['id'],assignment_responses)
+            if assignments:
+                profile['assignments'] = assignments   
 
         pid = profile['id']
         remove_keys = {'id', 'createdDateTime', 'version',

--- a/src/IntuneCD/backup_shellScripts.py
+++ b/src/IntuneCD/backup_shellScripts.py
@@ -27,7 +27,7 @@ endpoint = "https://graph.microsoft.com/beta/deviceManagement/deviceShellScripts
 assignment_endpoint = "https://graph.microsoft.com/beta/deviceManagement/deviceManagementScripts"
 
 ## Get all Shell scripts and save them in specified path
-def savebackup(path, output, token):
+def savebackup(path, output, exclude, token):
     configpath = path+"/"+"Scripts/Shell/"
     data = makeapirequest(endpoint, token)
     script_ids = []
@@ -38,9 +38,10 @@ def savebackup(path, output, token):
     script_data_responses = batch_request(script_ids,f'deviceManagement/deviceShellScripts/','',token)
 
     for script_data in script_data_responses:
-        assignments = get_object_assignment(script_data['id'],assignment_responses)
-        if assignments:
-            script_data['assignments'] = assignments
+        if "assignments" not in exclude:
+            assignments = get_object_assignment(script_data['id'],assignment_responses)
+            if assignments:
+                script_data['assignments'] = assignments
 
         remove_keys = {'id', 'createdDateTime',
                        'version', 'lastModifiedDateTime'}

--- a/src/IntuneCD/backup_windowsEnrollmentProfile.py
+++ b/src/IntuneCD/backup_windowsEnrollmentProfile.py
@@ -25,16 +25,17 @@ from .graph_batch import batch_assignment,get_object_assignment
 endpoint = "https://graph.microsoft.com/beta/deviceManagement/windowsAutopilotDeploymentProfiles"
 
 ## Get all Windows Enrollment Profiles and save them in specified path
-def savebackup(path, output, token):
+def savebackup(path, output, exclude, token):
     configpath = path+"/"+"Enrollment Profiles/Windows/"
     data = makeapirequest(endpoint, token)
 
     assignment_responses = batch_assignment(data,'deviceManagement/windowsAutopilotDeploymentProfiles/','/assignments',token)
 
     for profile in data['value']:
-        assignments = get_object_assignment(profile['id'],assignment_responses)
-        if assignments:
-            profile['assignments'] = assignments
+        if "assignments" not in exclude:
+            assignments = get_object_assignment(profile['id'],assignment_responses)
+            if assignments:
+                profile['assignments'] = assignments
         
         remove_keys = {'id', 'createdDateTime',
                        'version', 'lastModifiedDateTime'}

--- a/src/IntuneCD/graph_batch.py
+++ b/src/IntuneCD/graph_batch.py
@@ -151,6 +151,8 @@ def batch_intents(data, token) -> dict:
     base_url = 'deviceManagement'
     template_ids = []
     settings_id = []
+    categories_responses = []
+    settings_responses = []
     intent_values = {'value': []}
 
     ## Get each template ID

--- a/src/IntuneCD/run_backup.py
+++ b/src/IntuneCD/run_backup.py
@@ -37,6 +37,11 @@ def start():
                 "params:DEV_TENANT_NAME, DEV_CLIENT_ID, DEV_CLIENT_SECRET when run in devtoprod"),
         type=str
     )
+    parser.add_option(
+        "-e", "--exclude",
+        help = "List of objects to exclude from the backup, separated by commas. Currently supported objects are: assignments",
+        type = str
+    )
 
     (opts, _) = parser.parse_args()
 
@@ -57,13 +62,13 @@ def start():
 
     token = getAuth(selected_mode(opts.mode),opts.localauth,tenant="DEV")
 
-    def run_backup(path,output,token):
+    def run_backup(path,output,exclude,token):
 
         from .backup_appConfiguration import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
         from .backup_AppProtection import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
         from .backup_apns import savebackup
         savebackup(path,output,token)
@@ -72,22 +77,22 @@ def start():
         savebackup(path,output,token)
 
         from .backup_applications import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
         from .backup_compliance import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
         from .backup_notificationTemplate import savebackup
         savebackup(path,output,token)
 
         from .backup_profiles import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
         from .backup_appleEnrollmentProfile import savebackup
         savebackup(path,output,token)
 
         from .backup_windowsEnrollmentProfile import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
         from .backup_assignmentFilters import savebackup
         savebackup(path,output,token)
@@ -96,7 +101,7 @@ def start():
         savebackup(path,output,token)
 
         from .backup_managementIntents import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
         from .backup_compliancePartner import savebackup
         savebackup(path,output,token)
@@ -108,23 +113,27 @@ def start():
         savebackup(path,output,token)
 
         from .backup_proactiveRemediation import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
         from .backup_powershellScripts import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
         from .backup_shellScripts import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
         from .backup_configurationPolicies import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
 
     if opts.output == 'json' or opts.output == 'yaml':
         if token is None:
             raise Exception("Token is empty, please check os.environ variables")
         else:
-            run_backup(opts.path,opts.output,token)
+            if opts.exclude:
+                exclude = opts.exclude.split(",")
+            else:
+                exclude = []
+            run_backup(opts.path,opts.output,exclude,token)
 
     else:
         print('Please enter a valid output format, json or yaml') 

--- a/src/IntuneCD/update_appProtection.py
+++ b/src/IntuneCD/update_appProtection.py
@@ -56,6 +56,14 @@ def update(path, token, assignment=False):
                         f = open(file)
                         repo_data = json.load(f)
 
+                    if repo_data:
+                        if repo_data['@odata.type'] == "#microsoft.graph.mdmWindowsInformationProtectionPolicy":
+                            platform = "mdmWindowsInformationProtectionPolicies"
+                        elif repo_data['@odata.type'] == "#microsoft.graph.windowsInformationProtectionPolicy":
+                            platform = "windowsInformationProtectionPolicies"
+                        else:
+                            platform = f"{str(repo_data['@odata.type']).split('.')[2]}s"
+
                     ## Create object to pass in to assignment function
                     assign_obj = {}
                     if "assignments" in repo_data:
@@ -82,13 +90,6 @@ def update(path, token, assignment=False):
                         remove_keys = {'id', 'createdDateTime','version','lastModifiedDateTime'}
                         for k in remove_keys:
                             data['value'].pop(k, None)
-
-                        if repo_data['@odata.type'] == "#microsoft.graph.mdmWindowsInformationProtectionPolicy":
-                            platform = "mdmWindowsInformationProtectionPolicies"
-                        elif repo_data['@odata.type'] == "#microsoft.graph.windowsInformationProtectionPolicy":
-                            platform = "windowsInformationProtectionPolicies"
-                        else:
-                            platform = f"{str(repo_data['@odata.type']).split('.')[2]}s"
 
                         diff = DeepDiff(data['value'], repo_data, ignore_order=True).get('values_changed', {})
 

--- a/src/IntuneCD/update_assignment.py
+++ b/src/IntuneCD/update_assignment.py
@@ -69,6 +69,7 @@ def update_assignment(repo,mem,token) -> list:
 
     diff = DeepDiff(mem,repo,ignore_order=True)
     added = diff.get('iterable_item_added', {})
+    update = False
 
     if diff:
         for val in repo:
@@ -91,16 +92,22 @@ def update_assignment(repo,mem,token) -> list:
                 if val['target']['deviceAndAppManagementAssignmentFilterId'] is None:
                     val['target'].pop('deviceAndAppManagementAssignmentFilterId')
                     val['target'].pop('deviceAndAppManagementAssignmentFilterType')
-                    
-        ## Print added assignments
-        if added:
-            print('Updating assignments, added assignments:')
-            updates = get_added_removed(added)
-            for update in updates:
-                print(update)
-            return repo
-        else:
-            return None
+
+        for val in repo:
+            if 'groupId' in val['target'] or '#microsoft.graph.allDevicesAssignmentTarget' in val['target']['@odata.type'] \
+            or '#microsoft.graph.allLicensedUsersAssignmentTarget' in val['target']['@odata.type']:
+                update = True
+
+        if update is True:
+            ## Print added assignments
+            if added:
+                print('Updating assignments, added assignments:')
+                updates = get_added_removed(added)
+                for update in updates:
+                    print(update)
+                return repo
+            else:
+                return None
 
 def post_assignment_update(object,id,url,extra_url,token,status_code=200):
     request_json = json.dumps(object)

--- a/src/IntuneCD/update_proactiveRemediation.py
+++ b/src/IntuneCD/update_proactiveRemediation.py
@@ -124,6 +124,7 @@ def update(path, token, assignment=False):
                                 repo_data['remediationScriptContent'] = base64.b64encode(
                                     remediation_bytes).decode('utf-8')
                                 request_data = json.dumps(repo_data)
+                                q_param = None
                                 makeapirequestPatch(endpoint + "/" + mem_id, token,q_param,request_data)
                             else:
                                 print(

--- a/src/IntuneCD/update_profiles.py
+++ b/src/IntuneCD/update_profiles.py
@@ -124,6 +124,7 @@ def update(path, token, assignment=False):
                                         repo_payload_config)
                                     repo_data['payload'] = str(base64.b64encode(payload), 'utf-8')
                                     request_data = json.dumps(repo_data)
+                                    q_param = None
                                     makeapirequestPatch(endpoint + "/" + mem_id, token,q_param,request_data,status_code=204)
                                 else:
                                     print(
@@ -189,6 +190,7 @@ def update(path, token, assignment=False):
 
                             if repo_omas:
                                 request_data = json.dumps(repo_data)
+                                q_param = None
                                 makeapirequestPatch(endpoint + "/" + mem_id, token,q_param,request_data,status_code=204)
 
                         ## If Device Configuration is not custom, compare the values
@@ -207,6 +209,7 @@ def update(path, token, assignment=False):
                                     print(
                                         f"Setting: {setting}, New Value: {new_val}, Old Value: {old_val}")
                                 request_data = json.dumps(repo_data)
+                                q_param = None
                                 makeapirequestPatch(endpoint + "/" + mem_id, token,q_param,request_data,status_code=204)
                             else:
                                 print('No difference found for profile: ' + \

--- a/src/IntuneCD/update_profiles.py
+++ b/src/IntuneCD/update_profiles.py
@@ -252,6 +252,6 @@ def update(path, token, assignment=False):
                         assignment = update_assignment(assign_obj,mem_assign_obj,token)
                         if assignment is not None:
                             request_data = {}
-                            request_data['deviceHealthScriptAssignments'] = assignment
+                            request_data['assignments'] = assignment
                             post_assignment_update(request_data,post_request['id'],'deviceManagement/deviceConfigurations','assign',token)
                         print("Profile created with id: " + post_request['id'])

--- a/src/IntuneCD/update_shellScripts.py
+++ b/src/IntuneCD/update_shellScripts.py
@@ -93,9 +93,8 @@ def update(path, token, assignment=False):
 
                             ## If any changed values are found, push them to Intune
                             if pdiff or cdiff:
+                                print("Updating Shell script: " + repo_data['displayName'] + ", values changed:")
                                 if cdiff:
-                                    print(
-                                        "Updating Shell script: " + repo_data['displayName'] + ", values changed:")
                                     for key, value in cdiff.items():
                                         setting = re.search(
                                             "\[(.*)\]", key).group(1)
@@ -111,6 +110,7 @@ def update(path, token, assignment=False):
                                 repo_data['scriptContent'] = base64.b64encode(
                                     shell_bytes).decode('utf-8')
                                 request_data = json.dumps(repo_data)
+                                q_param = None
                                 makeapirequestPatch(endpoint + "/" + mem_id, token,q_param,request_data)
                             else:
                                 print(

--- a/src/IntuneCD/update_windowsEnrollmentProfile.py
+++ b/src/IntuneCD/update_windowsEnrollmentProfile.py
@@ -118,6 +118,6 @@ def update(path, token, assignment=False):
                         assignment = update_assignment(assign_obj,mem_assign_obj,token)
                         if assignment is not None:
                             request_data = {}
-                            request_data['target'] = assignment
-                            post_assignment_update(request_data,post_request['id'],'deviceManagement/windowsAutopilotDeploymentProfiles','assign',token,status_code=201)
+                            request_data['target'] = assignment[0]['target']
+                            post_assignment_update(request_data,post_request['id'],'deviceManagement/windowsAutopilotDeploymentProfiles','assignments',token,status_code=201)
                         print("Autopilot profile created with id: " + post_request['id'])

--- a/src/IntuneCD/update_windowsEnrollmentProfile.py
+++ b/src/IntuneCD/update_windowsEnrollmentProfile.py
@@ -93,6 +93,7 @@ def update(path, token, assignment=False):
                             else:
                                 repo_data['managementServiceAppId'] = ""
                             request_data = json.dumps(repo_data)
+                            q_param = None
                             makeapirequestPatch(endpoint + "/" + mem_id, token,q_param,request_data)
                         else:
                             print(


### PR DESCRIPTION
- Added ability to split documentation into categories using `-s Y` in `intunecd-startdocumentation`
- Added ability to set max length of output in documentation using `-m {int_value}` in `intunecd-startdocumentation`
- Added backup and documentation of Group Policy Configurations
- Added retry if 503 is encountered during a graph call

Closes #36 
Closes #35 
Closes #33 
Closes #27 