### PR TITLE
Version 1.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ The main function is to back up configurations from Intune to a Git repositry fr
 
 The package can also be run standalone outside of a pipeline, or in one to only backup data. Since 1.0.4, configurations are also created if they cannot be found. This means this tool could be used in a tenant to tenant migration scenario as well.
 
+## Whats new in 1.1.0
+- Bug fix for App Protection policies not being able to be created in a tenant to tenant scenario
+- Bug fix for Configuration Profiles not being able to update assignment in a tenant to tenant scenario
+- Bug fix for Windows Autopilot profiles not being able to update assignment in a tenant to tenant scenario
+- Bug fix for assignment updates where updating assignments when creating new configurations were not possible if the group does not exist
+
 ## Whats new in 1.0.9
 - Bug fix where the script exited with "local variable referenced before assignment" if a management intent does not exist
 - Added a new parameter to let you exclude assignments from backups. To exclude assignments from backup, you can now use `-e assignments` when running IntuneCD-startbackup.
@@ -35,17 +41,6 @@ Main focus for this release has been to improve the performance as large setups 
 - Assignments are now batched using the new batching module
 - If 504 or 502 is encounterd while getting configurations, the tool will now try again to get the configuration
 - For Windows apps in documentation, detection scripts etc will now have a "Click to expand..." instead of showing the whole script
-
-## Whats new in 1.0.7
-- Added backup and documentation of Apple Push Notification configuration
-- Added backup and documentation of Apple Volume Purchase Program tokens
-- Added backup and documentation of Applications
-- Added backup and documentation of Managed Google Play Configuration
-- Added backup and documentation of Partner Connections (Compliance, Management and Remote Assistance)
-- Added backup, documentation and update module for Proactive Remediations
-- Added a new option to the documentation module, '-i', which lets you configure your own introduction that will be displayed at the top
-- Changed documentation to display a collapsible view of long strings, now you can see the whole script payload for example
-- Improved console output when changes are detected, instead of writing the full path to the key, old output: `Setting: 'PayloadContent'][0]['PayloadContent']['corp.sap.privileges']['Forced'][0]['mcx_preference_settings']['ReasonMinLength', New Value: 15, Old Value: 20`, new output: `Setting: 'ReasonMinLength', New Value: 15, Old Value: 20`
 
 ## Install this package
 ```python

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,3 +3,4 @@ ignore:
   - "src/IntuneCD/run_update.py"
   - "src/IntuneCD/run_documentation.py"
   - "src/IntuneCD/get_accesstoken.py"
+  - "src/IntuneCD/backup_autopilotDevices.py"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 1.1.2
+version = 1.1.3
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 1.0.9
+version = 1.1.0
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/src/IntuneCD/backup_enrollmentStatusPage.py
+++ b/src/IntuneCD/backup_enrollmentStatusPage.py
@@ -55,8 +55,9 @@ def savebackup(path, output, exclude, token):
                     app_data = makeapirequest(APP_ENDPOINT + "/" + app_id, token)
                     app = {'name': app_data['displayName'], 'type': app_data['@odata.type']}
                     app_names.append(app)
-                profile.pop('selectedMobileAppIds', None)
-                profile['selectedMobileAppNames'] = app_names
+                if app_names:
+                    profile.pop('selectedMobileAppIds', None)
+                    profile['selectedMobileAppNames'] = app_names
 
             print("Backing up Enrollment Status Page: " +
                 profile['displayName'])

--- a/src/IntuneCD/run_backup.py
+++ b/src/IntuneCD/run_backup.py
@@ -37,6 +37,11 @@ def start():
                 "params:DEV_TENANT_NAME, DEV_CLIENT_ID, DEV_CLIENT_SECRET when run in devtoprod"),
         type=str
     )
+    parser.add_option(
+        "-e", "--exclude",
+        help = "List of objects to exclude from the backup, separated by commas. Currently supported objects are: assignments",
+        type = str
+    )
 
     (opts, _) = parser.parse_args()
 
@@ -57,13 +62,13 @@ def start():
 
     token = getAuth(selected_mode(opts.mode),opts.localauth,tenant="DEV")
 
-    def run_backup(path,output,token):
+    def run_backup(path,output,exclude,token):
 
         from .backup_appConfiguration import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
         from .backup_AppProtection import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
         from .backup_apns import savebackup
         savebackup(path,output,token)
@@ -72,22 +77,22 @@ def start():
         savebackup(path,output,token)
 
         from .backup_applications import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
         from .backup_compliance import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
         from .backup_notificationTemplate import savebackup
         savebackup(path,output,token)
 
         from .backup_profiles import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
         from .backup_appleEnrollmentProfile import savebackup
         savebackup(path,output,token)
 
         from .backup_windowsEnrollmentProfile import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
         from .backup_assignmentFilters import savebackup
         savebackup(path,output,token)
@@ -96,7 +101,7 @@ def start():
         savebackup(path,output,token)
 
         from .backup_managementIntents import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
         from .backup_compliancePartner import savebackup
         savebackup(path,output,token)
@@ -108,23 +113,27 @@ def start():
         savebackup(path,output,token)
 
         from .backup_proactiveRemediation import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
         from .backup_powershellScripts import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
         from .backup_shellScripts import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
         from .backup_configurationPolicies import savebackup
-        savebackup(path,output,token)
+        savebackup(path,output,exclude,token)
 
 
     if opts.output == 'json' or opts.output == 'yaml':
         if token is None:
             raise Exception("Token is empty, please check os.environ variables")
         else:
-            run_backup(opts.path,opts.output,token)
+            if opts.exclude:
+                exclude = opts.exclude.split(",")
+            else:
+                exclude = []
+            run_backup(opts.path,opts.output,exclude,token)
 
     else:
         print('Please enter a valid output format, json or yaml') 

--- a/src/IntuneCD/run_backup.py
+++ b/src/IntuneCD/run_backup.py
@@ -86,7 +86,7 @@ def start():
         type=str)
     parser.add_argument(
         "-ap", "--autopilot",
-        help="If set, a record of autopilot devices will be saved"
+        help="If set to True, a record of autopilot devices will be saved"
     )
 
     args = parser.parse_args()

--- a/src/IntuneCD/update_appProtection.py
+++ b/src/IntuneCD/update_appProtection.py
@@ -56,6 +56,14 @@ def update(path, token, assignment=False):
                         f = open(file)
                         repo_data = json.load(f)
 
+                    if repo_data:
+                        if repo_data['@odata.type'] == "#microsoft.graph.mdmWindowsInformationProtectionPolicy":
+                            platform = "mdmWindowsInformationProtectionPolicies"
+                        elif repo_data['@odata.type'] == "#microsoft.graph.windowsInformationProtectionPolicy":
+                            platform = "windowsInformationProtectionPolicies"
+                        else:
+                            platform = f"{str(repo_data['@odata.type']).split('.')[2]}s"
+
                     ## Create object to pass in to assignment function
                     assign_obj = {}
                     if "assignments" in repo_data:
@@ -82,13 +90,6 @@ def update(path, token, assignment=False):
                         remove_keys = {'id', 'createdDateTime','version','lastModifiedDateTime'}
                         for k in remove_keys:
                             data['value'].pop(k, None)
-
-                        if repo_data['@odata.type'] == "#microsoft.graph.mdmWindowsInformationProtectionPolicy":
-                            platform = "mdmWindowsInformationProtectionPolicies"
-                        elif repo_data['@odata.type'] == "#microsoft.graph.windowsInformationProtectionPolicy":
-                            platform = "windowsInformationProtectionPolicies"
-                        else:
-                            platform = f"{str(repo_data['@odata.type']).split('.')[2]}s"
 
                         diff = DeepDiff(data['value'], repo_data, ignore_order=True).get('values_changed', {})
 

--- a/src/IntuneCD/update_assignment.py
+++ b/src/IntuneCD/update_assignment.py
@@ -69,6 +69,7 @@ def update_assignment(repo,mem,token) -> list:
 
     diff = DeepDiff(mem,repo,ignore_order=True)
     added = diff.get('iterable_item_added', {})
+    update = False
 
     if diff:
         for val in repo:
@@ -91,16 +92,22 @@ def update_assignment(repo,mem,token) -> list:
                 if val['target']['deviceAndAppManagementAssignmentFilterId'] is None:
                     val['target'].pop('deviceAndAppManagementAssignmentFilterId')
                     val['target'].pop('deviceAndAppManagementAssignmentFilterType')
-                    
-        ## Print added assignments
-        if added:
-            print('Updating assignments, added assignments:')
-            updates = get_added_removed(added)
-            for update in updates:
-                print(update)
-            return repo
-        else:
-            return None
+
+        for val in repo:
+            if 'groupId' in val['target'] or '#microsoft.graph.allDevicesAssignmentTarget' in val['target']['@odata.type'] \
+            or '#microsoft.graph.allLicensedUsersAssignmentTarget' in val['target']['@odata.type']:
+                update = True
+
+        if update is True:
+            ## Print added assignments
+            if added:
+                print('Updating assignments, added assignments:')
+                updates = get_added_removed(added)
+                for update in updates:
+                    print(update)
+                return repo
+            else:
+                return None
 
 def post_assignment_update(object,id,url,extra_url,token,status_code=200):
     request_json = json.dumps(object)

--- a/src/IntuneCD/update_enrollmentStatusPage.py
+++ b/src/IntuneCD/update_enrollmentStatusPage.py
@@ -74,6 +74,26 @@ def update(path, token, assignment=False):
                     # Remove keys before using DeepDiff
                     mem_data['value'][0] = remove_keys(mem_data['value'][0])
 
+                    # Get application ID of configured apps
+                    if 'selectedMobileAppNames' in repo_data:
+                        app_ids = []
+                        
+                        for app in repo_data['selectedMobileAppNames']:
+                            q_param = {
+                            "$filter": f"(isof('{str(app['type']).replace('#','')}'))", 
+                            "$search": '"' + app['name'] + '"'}
+
+                            app_request = makeapirequest(
+                                APP_ENDPOINT, token, q_param)
+                            if app_request['value']:
+                                app_ids.append(app_request['value'][0]['id'])
+
+                        if app_ids:
+                            repo_data.pop('selectedMobileAppNames', None)
+                            repo_data['selectedMobileAppIds'] = app_ids
+                        else:
+                            print("No app found with name: " + app['name'])
+
                     diff = DeepDiff(
                         data['value'],
                         repo_data,
@@ -89,26 +109,6 @@ def update(path, token, assignment=False):
                         values = get_diff_output(diff)
                         for value in values:
                             print(value)
-                        
-                        # Get application ID of configured apps
-                        if 'selectedMobileAppNames' in repo_data:
-                            app_ids = []
-                            
-                            for app in repo_data['selectedMobileAppNames']:
-                                q_param = {
-                                "$filter": f"(isof('{str(app['type']).replace('#','')}'))", 
-                                "$search": '"' + app['name'] + '"'}
-
-                                app_request = makeapirequest(
-                                    APP_ENDPOINT, token, q_param)
-                                if app_request['value']:
-                                    app_ids.append(app_request['value'][0]['id'])
-
-                            if app_ids:
-                                repo_data.pop('selectedMobileAppNames', None)
-                                repo_data['selectedMobileAppIds'] = app_ids
-                            else:
-                                print("No apps found with name: " + app['name'])
 
                         repo_data.pop('priority', None)
 

--- a/src/IntuneCD/update_profiles.py
+++ b/src/IntuneCD/update_profiles.py
@@ -252,6 +252,6 @@ def update(path, token, assignment=False):
                         assignment = update_assignment(assign_obj,mem_assign_obj,token)
                         if assignment is not None:
                             request_data = {}
-                            request_data['deviceHealthScriptAssignments'] = assignment
+                            request_data['assignments'] = assignment
                             post_assignment_update(request_data,post_request['id'],'deviceManagement/deviceConfigurations','assign',token)
                         print("Profile created with id: " + post_request['id'])

--- a/src/IntuneCD/update_windowsEnrollmentProfile.py
+++ b/src/IntuneCD/update_windowsEnrollmentProfile.py
@@ -118,6 +118,6 @@ def update(path, token, assignment=False):
                         assignment = update_assignment(assign_obj,mem_assign_obj,token)
                         if assignment is not None:
                             request_data = {}
-                            request_data['target'] = assignment
-                            post_assignment_update(request_data,post_request['id'],'deviceManagement/windowsAutopilotDeploymentProfiles','assign',token,status_code=201)
+                            request_data['target'] = assignment[0]['target']
+                            post_assignment_update(request_data,post_request['id'],'deviceManagement/windowsAutopilotDeploymentProfiles','assignments',token,status_code=201)
                         print("Autopilot profile created with id: " + post_request['id'])

--- a/tests/Backup/test_backup_enrollmentStatusPage.py
+++ b/tests/Backup/test_backup_enrollmentStatusPage.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+
+"""This module tests backing up Enrollment Status Page profiles."""
+
+import json
+import yaml
+import unittest
+
+from unittest.mock import patch
+from testfixtures import TempDirectory
+from src.IntuneCD.backup_enrollmentStatusPage import savebackup
+
+BATCH_ASSIGNMENT = [
+    {
+        'value': [
+            {
+                'id': '0',
+                'target': {'groupName': 'Group1'}}]}]
+OBJECT_ASSIGNMENT = [
+    {
+        'target': {
+            'groupName': 'Group1'}}]
+
+
+class TestBackupEnrollmentStatusPage(unittest.TestCase):
+    """Test class for backup_enrollmentStatusPage."""
+
+    def setUp(self):
+        self.directory = TempDirectory()
+        self.directory.create()
+        self.token = 'token'
+        self.exclude = []
+        self.saved_path = f"{self.directory.path}/Enrollment Profiles/Windows/ESP/test."
+        self.expected_data = {'assignments': [{'target': {'groupName': 'Group1'}}], 'displayName': 'test',
+                              'selectedMobileAppNames': [
+                                  {'name': 'app1',
+                                   'type': '#microsoft.graph.mobileApp'}],
+                              '@odata.type': '#microsoft.graph.windows10EnrollmentCompletionPageConfiguration'}
+        self.statuspage_profile = {
+            "value": [{
+                "@odata.type": "#microsoft.graph.windows10EnrollmentCompletionPageConfiguration",
+                "displayName": "test",
+                "id": "0",
+                "selectedMobileAppIds": ["0"],
+            }]}
+        self.app_data = {'displayName': "app1", '@odata.type': '#microsoft.graph.mobileApp'}
+
+        self.batch_assignment_patch = patch(
+            'src.IntuneCD.backup_enrollmentStatusPage.batch_assignment')
+        self.batch_assignment = self.batch_assignment_patch.start()
+        self.batch_assignment.return_value = BATCH_ASSIGNMENT
+
+        self.object_assignment_patch = patch(
+            'src.IntuneCD.backup_enrollmentStatusPage.get_object_assignment')
+        self.object_assignment = self.object_assignment_patch.start()
+        self.object_assignment.return_value = OBJECT_ASSIGNMENT
+
+        self.makeapirequest_patch = patch(
+            'src.IntuneCD.backup_enrollmentStatusPage.makeapirequest')
+        self.makeapirequest = self.makeapirequest_patch.start()
+        self.makeapirequest.side_effect = self.statuspage_profile, self.app_data
+
+    def tearDown(self):
+        self.directory.cleanup()
+        self.batch_assignment.stop()
+        self.object_assignment.stop()
+        self.makeapirequest.stop()
+
+    def test_backup_yml(self):
+        """The folder should be created, the file should have the expected contents, and the count should be 1."""
+
+        output = 'yaml'
+        count = savebackup(
+            self.directory.path,
+            output,
+            self.exclude,
+            self.token)
+
+        with open(self.saved_path + output, 'r') as f:
+            data = json.dumps(yaml.safe_load(f))
+            saved_data = json.loads(data)
+
+        self.assertTrue(f'{self.directory.path}/Enrollment Profiles/Windows')
+        self.assertEqual(self.expected_data, saved_data)
+        self.assertEqual(1, count)
+
+    def test_backup_json(self):
+        """The folder should be created, the file should have the expected contents, and the count should be 1."""
+
+        output = 'json'
+        count = savebackup(
+            self.directory.path,
+            output,
+            self.exclude,
+            self.token)
+
+        with open(self.saved_path + output, 'r') as f:
+            saved_data = json.load(f)
+
+        self.assertTrue(f'{self.directory.path}/Enrollment Profiles/Windows/ESP')
+        self.assertEqual(self.expected_data, saved_data)
+        self.assertEqual(1, count)
+
+    def test_backup_with_no_returned_data(self):
+        """The count should be 0 if no data is returned."""
+
+        self.makeapirequest.side_effect = [{'value': []}]
+        self.count = savebackup(
+            self.directory.path,
+            'json',
+            self.exclude,
+            self.token)
+
+        self.assertEqual(0, self.count)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/Update/test_update_enrollmentStatusPage.py
+++ b/tests/Update/test_update_enrollmentStatusPage.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+
+"""This module tests updating Enrollment Status Page profiles."""
+
+import unittest
+
+from testfixtures import TempDirectory
+from unittest.mock import patch
+from src.IntuneCD.update_enrollmentStatusPage import update
+
+
+class TestUpdateEnrollmentStatusPage(unittest.TestCase):
+    """Test class for update_enrollmentStatusPage."""
+
+    def setUp(self):
+        self.directory = TempDirectory()
+        self.directory.create()
+        self.directory.makedir("Enrollment Profiles/Windows/ESP")
+        self.directory.write(
+            "Enrollment Profiles/Windows/ESP/test.json", '{"test": "test"}',
+            encoding='utf-8')
+        self.token = 'token'
+        self.app_ids = {'value': [{'id': "0"}]}
+        self.mem_data = {"value": [{"@odata.type": "test",
+                                    "id": "0",
+                                    "displayName": "test",
+                                    "testvalue": "test",
+                                    "selectedMobileAppIds": ["1"],
+                                    "assignments": [{"target": {"groupId": "test"}}]}]}
+        self.repo_data = {"@odata.type": "test",
+                          "id": "0",
+                          "displayName": "test",
+                          "testvalue": "test1",
+                          "selectedMobileAppNames": [{'name': 'app1', 'type': '#graph.mobileApp'}],
+                          "assignments": [{"target": {"groupName": "test1"}}]}
+
+        self.batch_assignment_patch = patch(
+            'src.IntuneCD.update_enrollmentStatusPage.batch_assignment')
+        self.batch_assignment = self.batch_assignment_patch.start()
+
+        self.object_assignment_patch = patch(
+            'src.IntuneCD.update_enrollmentStatusPage.get_object_assignment')
+        self.object_assignment = self.object_assignment_patch.start()
+
+        self.makeapirequest_patch = patch(
+            'src.IntuneCD.update_enrollmentStatusPage.makeapirequest')
+        self.makeapirequest = self.makeapirequest_patch.start()
+        self.makeapirequest.side_effect = self.mem_data, self.app_ids
+
+        self.update_assignment_patch = patch(
+            'src.IntuneCD.update_enrollmentStatusPage.update_assignment')
+        self.update_assignment = self.update_assignment_patch.start()
+
+        self.load_file_patch = patch(
+            'src.IntuneCD.update_enrollmentStatusPage.load_file')
+        self.load_file = self.load_file_patch.start()
+        self.load_file.return_value = self.repo_data
+
+        self.post_assignment_update_patch = patch(
+            'src.IntuneCD.update_enrollmentStatusPage.post_assignment_update')
+        self.post_assignment_update = self.post_assignment_update_patch.start()
+
+        self.makeapirequestPatch_patch = patch(
+            'src.IntuneCD.update_enrollmentStatusPage.makeapirequestPatch')
+        self.makeapirequestPatch = self.makeapirequestPatch_patch.start()
+
+        self.makeapirequestPost_patch = patch(
+            'src.IntuneCD.update_enrollmentStatusPage.makeapirequestPost')
+        self.makeapirequestPost = self.makeapirequestPost_patch.start()
+        self.makeapirequestPost.return_value = {"id": "0"}
+
+    def tearDown(self):
+        self.directory.cleanup()
+        self.batch_assignment.stop()
+        self.object_assignment.stop()
+        self.makeapirequest.stop()
+        self.update_assignment.stop()
+        self.load_file.stop()
+        self.post_assignment_update.stop()
+        self.makeapirequestPatch.stop()
+        self.makeapirequestPost.stop()
+
+    def test_update_with_diffs_and_assignment(self):
+        """The count should be 1 and the post_assignment_update and makeapirequestPatch should be called."""
+
+        self.count = update(self.directory.path, self.token, assignment=True)
+
+        self.assertEqual(self.count, 1)
+        self.assertEqual(self.makeapirequestPatch.call_count, 1)
+        self.assertEqual(self.post_assignment_update.call_count, 1)
+
+    def test_update_with_diffs_no_assignment(self):
+        """The count should be 1 and the makeapirequestPatch should be called."""
+
+        self.count = update(self.directory.path, self.token, assignment=False)
+
+        self.assertEqual(self.count, 1)
+        self.assertEqual(self.makeapirequestPatch.call_count, 1)
+        self.assertEqual(self.post_assignment_update.call_count, 0)
+
+    def test_update_with_no_diffs_and_assignment(self):
+        """The count should be 0, the post_assignment_update should be called,
+         and makeapirequestPatch should not be called."""
+
+        self.mem_data["value"][0]["testvalue"] = "test1"
+        self.mem_data["value"][0]["selectedMobileAppIds"][0] = "0"
+
+        self.count = update(self.directory.path, self.token, assignment=True)
+
+        self.assertEqual(self.count, 0)
+        self.assertEqual(self.makeapirequestPatch.call_count, 0)
+        self.assertEqual(self.post_assignment_update.call_count, 1)
+
+    def test_update_with_no_diffs_no_assignment(self):
+        """The count should be 0, the post_assignment_update and makeapirequestPatch should not be called."""
+
+        self.mem_data["value"][0]["testvalue"] = "test1"
+        self.mem_data["value"][0]["selectedMobileAppIds"][0] = "0"
+
+        self.count = update(self.directory.path, self.token, assignment=False)
+
+        self.assertEqual(self.count, 0)
+        self.assertEqual(self.makeapirequestPatch.call_count, 0)
+        self.assertEqual(self.post_assignment_update.call_count, 0)
+
+    def test_update_config_not_found_and_assignment(self):
+        """The count should be 0, the post_assignment_update and makeapirequestPost should be called."""
+
+        self.mem_data["value"][0]["displayName"] = "test1"
+
+        self.count = update(self.directory.path, self.token, assignment=True)
+
+        self.assertEqual(self.count, 0)
+        self.assertEqual(self.makeapirequestPost.call_count, 1)
+        self.assertEqual(self.post_assignment_update.call_count, 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Added backup and update of Enrollment Status Page
- Configurations are now documented in alphabetical order
- Added the ability to backup all Autopilot devices. To save a record of your Autopilot devices, run the backup with the `-ap True` parameter

closes #53 