### PR TITLE
Bug fix for no 'grantControls'

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ The package can also be run standalone outside a pipeline, or in one to only bac
 # Exciting news 📣
 The front end for IntuneCD has now been released. Check it out [here](https://github.com/almenscorner/intunecd-monitor)
 
+## What's new in 1.2.1
+- Bug fix for back up of Conditional Access throwing `AttributeError: 'NoneType' object has no attribute 'pop'` when no `grantControls` were configured.
+
 ## What's new in 1.2.0
 - Improvements to documentation
   - If a setting within a table cell has multiple entries, they are now separated by a new line instead of just a comma

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 1.2.0
+version = 1.2.1
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/src/IntuneCD/backup_conditionalAccess.py
+++ b/src/IntuneCD/backup_conditionalAccess.py
@@ -33,7 +33,8 @@ def savebackup(path, output, token):
             print("Backing up Conditional Access policy: " + policy['displayName'])
 
             policy = makeapirequest(f"{ENDPOINT}/{policy['id']}", token)
-            policy['grantControls'].pop('authenticationStrength@odata.context', None)
+            if policy['grantControls']:
+                policy['grantControls'].pop('authenticationStrength@odata.context', None)
             policy = remove_keys(policy)
 
             # Get filename without illegal characters


### PR DESCRIPTION
- Bug fix for back up of Conditional Access throwing `AttributeError: 'NoneType' object has no attribute 'pop'` when no `grantControls` were configured.

closes #62 