### PR TITLE
BugFix: index.md creation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 1.2.7
+version = 1.2.8
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/src/IntuneCD/documentation_functions.py
+++ b/src/IntuneCD/documentation_functions.py
@@ -9,6 +9,7 @@ import json
 import os
 import glob
 import re
+import platform
 
 from pytablewriter import MarkdownTableWriter
 
@@ -408,13 +409,16 @@ def get_md_files(configpath):
     This function gets the Markdown files in the configpath directory.
     :return: List of Markdown files
     """
-
+    slash = "/"
+    os = platform.uname().system
+    if os == "Windows":
+        slash = "\\"
     md_files = []
     patterns = ["*/*.md", "*/*/*.md", "*/*/*/*.md"]
     for pattern in patterns:
         for filename in glob.glob(configpath + pattern, recursive=True):
-            filepath = filename.split("/")
-            configpathname = configpath.split("/")[-1]
+            filepath = filename.split(slash)
+            configpathname = configpath.split(slash)[-1]
             filepath = filepath[filepath.index(configpathname):]
             filepath = "/".join(filepath[1:])
 


### PR DESCRIPTION
The index file was not able to be created on Windows as the path was split using "/" and not "\". A platform check has been added to `documentation_functions` to determine which slash to use.