### PR TITLE
Bugfix - keys not removed when excluding assignments on compliance

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 1.2.8
+version = 1.2.9
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/src/IntuneCD/backup_compliance.py
+++ b/src/IntuneCD/backup_compliance.py
@@ -44,12 +44,12 @@ def savebackup(path, output, exclude, token):
             if assignments:
                 policy['assignments'] = assignments
 
-            policy = remove_keys(policy)
-            for rule in policy['scheduledActionsForRule']:
-                remove_keys(rule)
-            if policy['scheduledActionsForRule']:
-                for scheduled_config in policy['scheduledActionsForRule'][0]['scheduledActionConfigurations']:
-                    remove_keys(scheduled_config)
+        policy = remove_keys(policy)
+        for rule in policy['scheduledActionsForRule']:
+            remove_keys(rule)
+        if policy['scheduledActionsForRule']:
+            for scheduled_config in policy['scheduledActionsForRule'][0]['scheduledActionConfigurations']:
+                remove_keys(scheduled_config)
 
         # Get filename without illegal characters
         fname = clean_filename(policy['displayName'])


### PR DESCRIPTION
If assignments were excluded when running the backup, the removal of keys on compliance policies was also skipped. This has been fixed so keys are always removed.

closes #76 