### PR TITLE
ADAL to MSAL

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -45,3 +45,4 @@ jobs:
         files: ./coverage.xml
         flags: unittests
         fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -23,7 +23,17 @@ The package can also be run standalone outside a pipeline, or in one to only bac
 # Exciting news 📣
 The front end for IntuneCD has now been released. Check it out [here](https://github.com/almenscorner/intunecd-monitor)
 
-## Whats new in 1.3.1
+
+## What's new in 1.3.2
+The authentication module has been updated to MSAL, which replaces the deprecated ADAL library. This update brings additional authentication options, including Client Credentials and Certificate-based authentication.
+
+- **Client Credentials:** This method utilizes the `CLIENT_ID` and `CLIENT_SECRET` to authenticate.
+
+- **Certificate-based Authentication:** You can use a certificate uploaded to your Azure AD App Registration by adding the `-c` parameter. Additionally, you must set the environment variables `KEY_FILE` and `THUMBPRINT` to specify the path to the private key of the certificate and the thumbprint of the certificate, respectively. When using this option, **do not** specify the `-m` parameter.
+
+- **Interactive Authentication:** If you are running the tool interactively and wish to authenticate with your own account, add the `-i` parameter. This will open a browser window prompting you to authenticate. When using this option, **do not** specify the `-m` parameter.
+
+## What's new in 1.3.1
 - Bug fix for Filters not being able to created if they do not exist
 - Bug fix for Conditional Access policies not being able to be created if `authenticationStrength` is configured
 - Added Graph throttling handling to `makeapirequestPost` to handle creation of large amounts of CA policies
@@ -31,16 +41,6 @@ The front end for IntuneCD has now been released. Check it out [here](https://gi
 ## What's new in 1.3.0
 - New summary of changes, instead of just a count, a summary of the changes with old and new values are sent to the front end
 - Report mode, if you want to send a summary of changes to the front end without actually updating the configuration in Intune, you can activate report mode when running the update using `-r` -> `IntuneCD-startupdate -r`
-
-## What's new in 1.2.7
-- Documentation overhaul
-  - The documentation module has been completely overhauled. It is now much easier to read. Below you can see a before and after example,
-    - **Before**
-    
-    ![Screenshot 2022-12-08 at 10 28 13](https://user-images.githubusercontent.com/78877636/206411116-bdefbb4c-e485-4529-a86f-4f675845b6ab.png)
-    - **After**
-    
-    ![Screenshot 2022-12-08 at 10 26 18](https://user-images.githubusercontent.com/78877636/206411063-66838684-3511-44dc-8eaf-43aaa0b3cb94.png)
 
 ## I use Powershell, Do I need to learn Python?
 No.
@@ -96,6 +96,16 @@ If you just want to back up you can get away with only Read permission (except f
 
 ## How do I use it?
 You have two options, using a pipeline or running it locally. Let's have a look at both.
+
+### Authentication
+There are three options to choose from when running the tool to authenticate to Microsoft Graph.
+
+- Client Credentials
+  - This is using the client ID and client secret to authenticate
+- Certificate
+  - You can choose to authenticate with a certificate uploaded to your Azure AD App Registration by adding the `-c` parameter. In addition you must set ENV variables for `KEY_FILE` and specify the path to the private key of the certificate, and, `THUMBPRINT` and specify the thumbprint of the certificate added to the app registration. If using this option, **do not** specify the `-m` parameter.
+- Interactive
+  - If you are running the tool interactivly and want to authenticate with your own account, add the `-i` parameter. When the tool is run a browser window will open asking you to authenticate. If using this option, **do not** specify the `-m` parameter.
 
 ## Parameters
 To see which parameters you have to provide just type: IntuneCD-startbackup --help, IntuneCD-startupdate --help or IntuneCD-startdocumentation --help

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     <body>
         <!-- Navigation-->
         <nav class="navbar navbar-light bg-light static-top">
-            <div class="container">
+            <div class="container justify-content-center">
                 <div class="col-sm">
                     <a class="navbar-brand" href="https://github.com/almenscorner/intunecd">IntuneCD</a>
                 </div>
@@ -28,6 +28,12 @@
                 <div class="col-sm">
                     <a class="navbar-brand" href="https://www.linkedin.com/groups/9269061/">LinkedIn group</a>
             </div>
+            <div class="col-sm">
+                <a class="navbar-brand" href="https://intunecd.slack.com">Slack</a>
+        </div>
+        <div class="col-sm">
+            <a class="navbar-brand" href="https://discord.gg/msems">Discord</a>
+    </div>
         </nav>
         <!-- Masthead-->
         <header class="masthead">
@@ -155,6 +161,12 @@
                         <h2 class="mb-4">Leave a ⭐️ on GitHub!</h2>
                         <div class="col-auto">
                             <a class="btn btn-primary btn-lg" href="https://github.com/almenscorner/intunecd">Make it shine</a>
+                        </div>
+                    </div>
+                    <div class="col-xl-3 mb-4">
+                        <h2 class="mb-4">Join IntuneCD Slack!</h2>
+                        <div class="col-auto">
+                            <a class="btn btn-primary btn-lg" href="https://join.slack.com/t/intunecd/shared_invite/zt-1nf255xvo-POv60XoewYfY65TH9~tV_g">Join</a>
                         </div>
                     </div>
                 </div>

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 1.3.1
+version = 1.3.2
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune
@@ -22,10 +22,10 @@ python_requires = >=3.6
 install_requires =
     deepdiff>=5.6.0
     pyyaml>=6.0
-    adal>=1.2.7
     msrest>=0.6.21
     markdown_toclify>=0.1.7
     pytablewriter>=0.64.1
+    msal >= 1.20.0
 
 [options.packages.find]
 where = src

--- a/src/IntuneCD/get_accesstoken.py
+++ b/src/IntuneCD/get_accesstoken.py
@@ -4,22 +4,126 @@
 This module contains the functions used to get the access token for MS Graph.
 """
 
-from adal import AuthenticationContext
+
+from msal import ConfidentialClientApplication, PublicClientApplication
+
+AUTHORITY = "https://login.microsoftonline.com/"
+SCOPE = ["https://graph.microsoft.com/.default"]
 
 
-def obtain_accesstoken(TENANT_NAME, CLIENT_ID, CLIENT_SECRET, resource):
+def obtain_accesstoken_app(TENANT_NAME, CLIENT_ID, CLIENT_SECRET):
     """
-    This function is used to get an access token to MS Graph.
+    This function is used to get an access token to MS Graph using client credentials.
 
     :param TENANT_NAME: The name of the Azure tenant
     :param CLIENT_ID: The ID of the registered Azure AD application
     :param CLIENT_SECRET: Secret of the registered Azure AD application
-    :param resource: The resource to get an access token for
     :return: The access token
     """
 
-    auth_context = AuthenticationContext("https://login.microsoftonline.com/" + TENANT_NAME)
-    token = auth_context.acquire_token_with_client_credentials(
-        resource=resource, client_id=CLIENT_ID, client_secret=CLIENT_SECRET
+    # Create app instance
+    app = ConfidentialClientApplication(
+        client_id=CLIENT_ID,
+        client_credential=CLIENT_SECRET,
+        authority=AUTHORITY + TENANT_NAME,
     )
+
+    token = None
+
+    try:
+        # Check if token is already cached
+        token = app.acquire_token_silent(SCOPE, account=None)
+
+        # If not, get a new token
+        if not token:
+            token = app.acquire_token_for_client(scopes=SCOPE)
+            if not token:
+                raise Exception("No token returned")
+
+    except Exception as e:
+        raise Exception("Error obtaining access token: " + str(e))
+
+    return token
+
+
+def obtain_accesstoken_cert(TENANT_NAME, CLIENT_ID, THUMBPRINT, KEY_FILE):
+    """
+    This function is used to get an access token to MS Graph using a certificate.
+
+    :param TENANT_NAME: The name of the Azure tenant
+    :param CLIENT_ID: The ID of the registered Azure AD application
+    :param THUMBPRINT Thumbprint of the certificate uploaded to Azure AD
+    :param KEY_FILE: Path to the private key of the certificate
+    :return: The access token
+    """
+
+    # Create app instance
+    app = ConfidentialClientApplication(
+        client_id=CLIENT_ID,
+        client_credential={
+            "thumbprint": THUMBPRINT,
+            "private_key": open(KEY_FILE).read(),
+        },
+        authority=AUTHORITY + TENANT_NAME,
+    )
+
+    token = None
+
+    try:
+        # Check if token is already cached
+        token = app.acquire_token_silent(SCOPE, account=None)
+
+        # If not, get a new token
+        if not token:
+            token = app.acquire_token_for_client(scopes=SCOPE)
+            if not token:
+                raise Exception("No token returned")
+
+    except Exception as e:
+        raise Exception("Error obtaining access token: " + str(e))
+
+    return token
+
+
+def obtain_accesstoken_interactive(TENANT_NAME, CLIENT_ID):
+    """
+    This function is used to get an access token to MS Graph interactivly.
+
+    :param TENANT_NAME: The name of the Azure tenant
+    :param CLIENT_ID: The ID of the registered Azure AD application
+    :return: The access token
+    """
+
+    # Create app instance
+    app = PublicClientApplication(
+        client_id=CLIENT_ID,
+        client_credential=None,
+        authority=AUTHORITY + TENANT_NAME,
+    )
+
+    token = None
+
+    # Set the requited scopes
+    scopes = [
+        "DeviceManagementApps.ReadWrite.All",
+        "DeviceManagementConfiguration.ReadWrite.All",
+        "DeviceManagementManagedDevices.Read.All",
+        "DeviceManagementServiceConfig.ReadWrite.All",
+        "Group.Read.All",
+        "Policy.ReadWrite.ConditionalAccess",
+        "Policy.Read.All",
+    ]
+
+    try:
+        # Get the token interactively
+        token = app.acquire_token_interactive(
+            scopes=scopes, max_age=1200, prompt="select_account"
+        )
+
+        if not token:
+            raise Exception("No token returned")
+
+    except Exception as e:
+        raise Exception("Error obtaining access token: " + str(e))
+
     return token

--- a/src/IntuneCD/get_authparams.py
+++ b/src/IntuneCD/get_authparams.py
@@ -6,12 +6,17 @@ This module is used to get the access token for the tenant.
 
 import json
 import os
-from .get_accesstoken import obtain_accesstoken
+import subprocess
+import json
 
-resource = "https://graph.microsoft.com"
+from .get_accesstoken import (
+    obtain_accesstoken_app,
+    obtain_accesstoken_cert,
+    obtain_accesstoken_interactive,
+)
 
 
-def getAuth(mode, localauth, tenant):
+def getAuth(mode, localauth, certauth, interactiveauth, tenant):
     """
     This function authenticates to MS Graph and returns the access token.
 
@@ -21,37 +26,59 @@ def getAuth(mode, localauth, tenant):
     :return: The access token
     """
 
-    if mode == "devtoprod":
-        if localauth:
-            with open(localauth) as json_data:
-                auth_dict = json.load(json_data)
-            tenant_TENANT_NAME = auth_dict["params"][tenant + "_TENANT_NAME"]
-            tenant_CLIENT_ID = auth_dict["params"][tenant + "_CLIENT_ID"]
-            tenant_CLIENT_SECRET = auth_dict["params"][tenant + "_CLIENT_SECRET"]
-        else:
-            tenant_TENANT_NAME = os.environ.get(tenant + "_TENANT_NAME")
-            tenant_CLIENT_ID = os.environ.get(tenant + "_CLIENT_ID")
-            tenant_CLIENT_SECRET = os.environ.get(tenant + "_CLIENT_SECRET")
-        if (tenant_TENANT_NAME is None) or (tenant_CLIENT_ID is None) or (tenant_CLIENT_SECRET is None):
-            raise Exception("One or more os.environ variables for " + tenant + " not set")
-        else:
-            token = obtain_accesstoken(tenant_TENANT_NAME, tenant_CLIENT_ID, tenant_CLIENT_SECRET, resource)
-            return token
+    if certauth:
+        KEY_FILE = os.environ.get("KEY_FILE")
+        THUMBPRINT = os.environ.get("THUMBPRINT")
+        TENANT_NAME = os.environ.get("TENANT_NAME")
+        CLIENT_ID = os.environ.get("CLIENT_ID")
 
-    elif mode == "standalone":
-
-        if localauth:
-            with open(localauth) as json_data:
-                auth_dict = json.load(json_data)
-            TENANT_NAME = auth_dict["params"]["TENANT_NAME"]
-            CLIENT_ID = auth_dict["params"]["CLIENT_ID"]
-            CLIENT_SECRET = auth_dict["params"]["CLIENT_SECRET"]
-        else:
-            TENANT_NAME = os.environ.get("TENANT_NAME")
-            CLIENT_ID = os.environ.get("CLIENT_ID")
-            CLIENT_SECRET = os.environ.get("CLIENT_SECRET")
-        if (TENANT_NAME is None) or (CLIENT_ID is None) or (CLIENT_SECRET is None):
+        if not all([KEY_FILE, THUMBPRINT, TENANT_NAME, CLIENT_ID]):
             raise Exception("One or more os.environ variables not set")
-        else:
-            token = obtain_accesstoken(TENANT_NAME, CLIENT_ID, CLIENT_SECRET, resource)
-            return token
+        return obtain_accesstoken_cert(TENANT_NAME, CLIENT_ID, THUMBPRINT, KEY_FILE)
+
+    if interactiveauth:
+        TENANT_NAME = os.environ.get("TENANT_NAME")
+        CLIENT_ID = os.environ.get("CLIENT_ID")
+
+        if not all([TENANT_NAME, CLIENT_ID]):
+            raise Exception("One or more os.environ variables not set")
+
+        return obtain_accesstoken_interactive(TENANT_NAME, CLIENT_ID)
+
+    if mode:
+        if mode == "devtoprod":
+            if localauth:
+                with open(localauth) as json_data:
+                    auth_dict = json.load(json_data)
+                tenant_TENANT_NAME = auth_dict["params"][tenant + "_TENANT_NAME"]
+                tenant_CLIENT_ID = auth_dict["params"][tenant + "_CLIENT_ID"]
+                tenant_CLIENT_SECRET = auth_dict["params"][tenant + "_CLIENT_SECRET"]
+            else:
+                tenant_TENANT_NAME = os.environ.get(tenant + "_TENANT_NAME")
+                tenant_CLIENT_ID = os.environ.get(tenant + "_CLIENT_ID")
+                tenant_CLIENT_SECRET = os.environ.get(tenant + "_CLIENT_SECRET")
+            if not all([tenant_TENANT_NAME, tenant_CLIENT_ID, tenant_CLIENT_SECRET]):
+                raise Exception(
+                    "One or more os.environ variables for " + tenant + " not set"
+                )
+
+            return obtain_accesstoken_app(
+                tenant_TENANT_NAME, tenant_CLIENT_ID, tenant_CLIENT_SECRET
+            )
+
+        elif mode == "standalone":
+
+            if localauth:
+                with open(localauth) as json_data:
+                    auth_dict = json.load(json_data)
+                TENANT_NAME = auth_dict["params"]["TENANT_NAME"]
+                CLIENT_ID = auth_dict["params"]["CLIENT_ID"]
+                CLIENT_SECRET = auth_dict["params"]["CLIENT_SECRET"]
+            else:
+                TENANT_NAME = os.environ.get("TENANT_NAME")
+                CLIENT_ID = os.environ.get("CLIENT_ID")
+                CLIENT_SECRET = os.environ.get("CLIENT_SECRET")
+            if not all([TENANT_NAME, CLIENT_ID, CLIENT_SECRET]):
+                raise Exception("One or more os.environ variables not set")
+
+            return obtain_accesstoken_app(TENANT_NAME, CLIENT_ID, CLIENT_SECRET)

--- a/src/IntuneCD/graph_request.py
+++ b/src/IntuneCD/graph_request.py
@@ -21,7 +21,7 @@ def makeapirequest(endpoint, token, q_param=None):
 
     headers = {
         "Content-Type": "application/json",
-        "Authorization": "Bearer {0}".format(token["accessToken"]),
+        "Authorization": "Bearer {0}".format(token["access_token"]),
     }
 
     if q_param is not None:
@@ -101,7 +101,7 @@ def makeapirequestPatch(
 
     headers = {
         "Content-Type": "application/json",
-        "Authorization": "Bearer {0}".format(token["accessToken"]),
+        "Authorization": "Bearer {0}".format(token["access_token"]),
     }
 
     if q_param is not None:
@@ -131,7 +131,7 @@ def makeapirequestPost(patchEndpoint, token, q_param=None, jdata=None, status_co
 
     headers = {
         "Content-Type": "application/json",
-        "Authorization": "Bearer {0}".format(token["accessToken"]),
+        "Authorization": "Bearer {0}".format(token["access_token"]),
     }
 
     if q_param is not None:
@@ -172,7 +172,7 @@ def makeapirequestPut(patchEndpoint, token, q_param=None, jdata=None, status_cod
 
     headers = {
         "Content-Type": "application/json",
-        "Authorization": "Bearer {0}".format(token["accessToken"]),
+        "Authorization": "Bearer {0}".format(token["access_token"]),
     }
 
     if q_param is not None:

--- a/src/IntuneCD/run_backup.py
+++ b/src/IntuneCD/run_backup.py
@@ -69,6 +69,18 @@ def start():
         type=str,
     )
     parser.add_argument(
+        "-c",
+        "--certauth",
+        help="When using certificate auth, the following ENV variables is required: TENANT_NAME, CLIENT_ID, THUMBPRINT, KEY_FILE",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-i",
+        "--interactiveauth",
+        help="When using interactive auth, the following ENV variables is required: TENANT_NAME, CLIENT_ID",
+        action="store_true",
+    )
+    parser.add_argument(
         "-e",
         "--exclude",
         help="List of objects to exclude from the backup, separated by space.",
@@ -101,9 +113,16 @@ def start():
         nargs="+",
     )
     parser.add_argument(
-        "-f", "--frontend", help="Set the frontend URL to update with configuration count and backup stream", type=str
+        "-f",
+        "--frontend",
+        help="Set the frontend URL to update with configuration count and backup stream",
+        type=str,
     )
-    parser.add_argument("-ap", "--autopilot", help="If set to True, a record of autopilot devices will be saved")
+    parser.add_argument(
+        "-ap",
+        "--autopilot",
+        help="If set to True, a record of autopilot devices will be saved",
+    )
 
     args = parser.parse_args()
 
@@ -119,7 +138,18 @@ def start():
         func = switcher.get(argument, "nothing")
         return func()
 
-    token = getAuth(selected_mode(args.mode), args.localauth, tenant="DEV")
+    if args.certauth or args.interactiveauth:
+        args.mode = None
+    else:
+        args.mode = selected_mode(args.mode)
+
+    token = getAuth(
+        args.mode,
+        args.localauth,
+        args.certauth,
+        args.interactiveauth,
+        tenant="DEV",
+    )
 
     def run_backup(path, output, exclude, token):
 

--- a/src/IntuneCD/run_update.py
+++ b/src/IntuneCD/run_update.py
@@ -64,6 +64,18 @@ def start():
         type=str,
     )
     parser.add_argument(
+        "-c",
+        "--certauth",
+        help="When using certificate auth, the following ENV variables is required: TENANT_NAME, CLIENT_ID, THUMBPRINT, KEY_FILE",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-i",
+        "--interactiveauth",
+        help="When using interactive auth, the following ENV variables is required: TENANT_NAME, CLIENT_ID",
+        action="store_true",
+    )
+    parser.add_argument(
         "-u",
         help="When this parameter is set, assignments are updated for all configurations",
         action="store_true",
@@ -118,7 +130,18 @@ def start():
         func = switcher.get(argument, "nothing")
         return func()
 
-    token = getAuth(selected_mode(args.mode), args.localauth, tenant="PROD")
+    if args.certauth or args.interactiveauth:
+        args.mode = None
+    else:
+        args.mode = selected_mode(args.mode)
+
+    token = getAuth(
+        args.mode,
+        args.localauth,
+        args.certauth,
+        args.interactiveauth,
+        tenant="PROD",
+    )
 
     def run_update(path, token, assignment, exclude, report):
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@ pyyaml>=6.0
 testfixtures>=7.0
 deepdiff>=5.6.0
 requests
-adal
+msal
 pytest==6.2.5
 pytest-cov==3.0.0
 pytablewriter

--- a/tests/test_get_authparams.py
+++ b/tests/test_get_authparams.py
@@ -12,7 +12,11 @@ from src.IntuneCD.get_authparams import getAuth
 
 
 @patch("src.IntuneCD.get_authparams.getAuth")
-@patch("src.IntuneCD.get_authparams.obtain_accesstoken", return_value="token")
+@patch("src.IntuneCD.get_authparams.obtain_accesstoken_app", return_value="token")
+@patch("src.IntuneCD.get_authparams.obtain_accesstoken_cert", return_value="token")
+@patch(
+    "src.IntuneCD.get_authparams.obtain_accesstoken_interactive", return_value="token"
+)
 class TestGetAuth(unittest.TestCase):
     """Test class for get_auth."""
 
@@ -30,7 +34,9 @@ class TestGetAuth(unittest.TestCase):
             encoding="utf-8",
         )
         self.directory.write(
-            "auth.json", '{"params": {"CLIENT_ID": "test", "CLIENT_SECRET": "test", "TENANT_NAME": "test"}}', encoding="utf-8"
+            "auth.json",
+            '{"params": {"CLIENT_ID": "test", "CLIENT_SECRET": "test", "TENANT_NAME": "test"}}',
+            encoding="utf-8",
         )
         self.auth_dev_json = self.directory.path + "/auth_dev.json"
         self.auth_prod_json = self.directory.path + "/auth_prod.json"
@@ -39,56 +45,273 @@ class TestGetAuth(unittest.TestCase):
     def tearDown(self):
         self.directory.cleanup()
 
-    def test_get_auth_devtoprod_env_dev(self, mock_getAuth, mock_obtain_accesstoken):
+    def test_get_auth_devtoprod_env_dev_app(
+        self,
+        mock_getAuth,
+        mock_obtain_accesstoken_app,
+        mock_obtain_accesstoken_cert,
+        mock_obtain_accesstoken_interactive,
+    ):
         """The auth params should be returned."""
-        with patch.dict("os.environ", {"DEV_CLIENT_ID": "test", "DEV_CLIENT_SECRET": "test", "DEV_TENANT_NAME": "test"}):
-            result = getAuth("devtoprod", localauth=None, tenant="DEV")
+        with patch.dict(
+            "os.environ",
+            {
+                "DEV_CLIENT_ID": "test",
+                "DEV_CLIENT_SECRET": "test",
+                "DEV_TENANT_NAME": "test",
+            },
+        ):
+            result = getAuth(
+                "devtoprod",
+                localauth=None,
+                certauth=None,
+                interactiveauth=None,
+                tenant="DEV",
+            )
             self.assertEqual(result, "token")
 
-    def test_get_auth_devtoprod_env_prod(self, mock_getAuth, mock_obtain_accesstoken):
+    def test_get_auth_devtoprod_env_prod(
+        self,
+        mock_getAuth,
+        mock_obtain_accesstoken_app,
+        mock_obtain_accesstoken_cert,
+        mock_obtain_accesstoken_interactive,
+    ):
         """The auth params should be returned."""
-        with patch.dict("os.environ", {"PROD_CLIENT_ID": "test", "PROD_CLIENT_SECRET": "test", "PROD_TENANT_NAME": "test"}):
-            result = getAuth("devtoprod", localauth=None, tenant="PROD")
+        with patch.dict(
+            "os.environ",
+            {
+                "PROD_CLIENT_ID": "test",
+                "PROD_CLIENT_SECRET": "test",
+                "PROD_TENANT_NAME": "test",
+            },
+        ):
+            result = getAuth(
+                "devtoprod",
+                localauth=None,
+                certauth=None,
+                interactiveauth=None,
+                tenant="PROD",
+            )
             self.assertEqual(result, "token")
 
-    def test_get_auth_devtoprod_localauth_dev(self, mock_getAuth, mock_obtain_accesstoken):
+    def test_get_auth_devtoprod_localauth_dev(
+        self,
+        mock_getAuth,
+        mock_obtain_accesstoken_app,
+        mock_obtain_accesstoken_cert,
+        mock_obtain_accesstoken_interactive,
+    ):
         """The auth params should be returned."""
-        result = getAuth("devtoprod", localauth=self.auth_dev_json, tenant="DEV")
+        result = getAuth(
+            "devtoprod",
+            localauth=self.auth_dev_json,
+            certauth=None,
+            interactiveauth=None,
+            tenant="DEV",
+        )
         self.assertEqual(result, "token")
 
-    def test_get_auth_devtoprod_localauth_prod(self, mock_getAuth, mock_obtain_accesstoken):
+    def test_get_auth_devtoprod_localauth_prod(
+        self,
+        mock_getAuth,
+        mock_obtain_accesstoken_app,
+        mock_obtain_accesstoken_cert,
+        mock_obtain_accesstoken_interactive,
+    ):
         """The auth params should be returned."""
-        result = getAuth("devtoprod", localauth=self.auth_prod_json, tenant="PROD")
+        result = getAuth(
+            "devtoprod",
+            localauth=self.auth_prod_json,
+            certauth=None,
+            interactiveauth=None,
+            tenant="PROD",
+        )
         self.assertEqual(result, "token")
 
-    def test_get_auth_standalone_env(self, mock_getAuth, mock_obtain_accesstoken):
+    def test_get_auth_standalone_env(
+        self,
+        mock_getAuth,
+        mock_obtain_accesstoken_app,
+        mock_obtain_accesstoken_cert,
+        mock_obtain_accesstoken_interactive,
+    ):
         """The auth params should be returned."""
-        with patch.dict("os.environ", {"CLIENT_ID": "test", "CLIENT_SECRET": "test", "TENANT_NAME": "test"}):
-            result = getAuth("standalone", localauth=None, tenant=None)
+        with patch.dict(
+            "os.environ",
+            {"CLIENT_ID": "test", "CLIENT_SECRET": "test", "TENANT_NAME": "test"},
+        ):
+            result = getAuth(
+                "standalone",
+                localauth=None,
+                certauth=None,
+                interactiveauth=None,
+                tenant=None,
+            )
             self.assertEqual(result, "token")
 
-    def test_get_auth_standalone_localauth(self, mock_getAuth, mock_obtain_accesstoken):
+    def test_get_auth_standalone_localauth(
+        self,
+        mock_getAuth,
+        mock_obtain_accesstoken_app,
+        mock_obtain_accesstoken_cert,
+        mock_obtain_accesstoken_interactive,
+    ):
         """The auth params should be returned."""
-        result = getAuth("standalone", localauth=self.auth_json, tenant=None)
+        result = getAuth(
+            "standalone",
+            localauth=self.auth_json,
+            certauth=None,
+            interactiveauth=None,
+            tenant=None,
+        )
         self.assertEqual(result, "token")
 
-    def test_get_auth_devtoprod_missing_env_dev(self, mock_getAuth, mock_obtain_accesstoken):
+    def test_get_auth_devtoprod_missing_env_dev(
+        self,
+        mock_getAuth,
+        mock_obtain_accesstoken_app,
+        mock_obtain_accesstoken_cert,
+        mock_obtain_accesstoken_interactive,
+    ):
         """Exception should be raised due to missing env."""
-        with patch.dict("os.environ", {"DEV_CLIENT_ID": "test", "DEV_CLIENT_SECRET": "test"}):
+        with patch.dict(
+            "os.environ", {"DEV_CLIENT_ID": "test", "DEV_CLIENT_SECRET": "test"}
+        ):
             with self.assertRaises(Exception):
-                getAuth("devtoprod", localauth=None, tenant="DEV")
+                getAuth(
+                    "devtoprod",
+                    localauth=None,
+                    certauth=None,
+                    interactiveauth=None,
+                    tenant="DEV",
+                )
 
-    def test_get_auth_devtoprod_missing_env_prod(self, mock_getAuth, mock_obtain_accesstoken):
+    def test_get_auth_devtoprod_missing_env_prod(
+        self,
+        mock_getAuth,
+        mock_obtain_accesstoken_app,
+        mock_obtain_accesstoken_cert,
+        mock_obtain_accesstoken_interactive,
+    ):
         """Exception should be raised due to missing env."""
-        with patch.dict("os.environ", {"PROD_CLIENT_ID": "test", "PROD_CLIENT_SECRET": "test"}):
+        with patch.dict(
+            "os.environ", {"PROD_CLIENT_ID": "test", "PROD_CLIENT_SECRET": "test"}
+        ):
             with self.assertRaises(Exception):
-                getAuth("devtoprod", localauth=None, tenant="PROD")
+                getAuth(
+                    "devtoprod",
+                    localauth=None,
+                    certauth=None,
+                    interactiveauth=None,
+                    tenant="PROD",
+                )
 
-    def test_get_auth_standalone_missing_env(self, mock_getAuth, mock_obtain_accesstoken):
+    def test_get_auth_standalone_missing_env(
+        self,
+        mock_getAuth,
+        mock_obtain_accesstoken_app,
+        mock_obtain_accesstoken_cert,
+        mock_obtain_accesstoken_interactive,
+    ):
         """Exception should be raised due to missing env."""
         with patch.dict("os.environ", {"CLIENT_ID": "test", "CLIENT_SECRET": "test"}):
             with self.assertRaises(Exception):
-                getAuth("standalone", localauth=None, tenant=None)
+                getAuth(
+                    "standalone",
+                    localauth=None,
+                    certauth=None,
+                    interactiveauth=None,
+                    tenant=None,
+                )
+
+    def test_get_auth_cert(
+        self,
+        mock_getAuth,
+        mock_obtain_accesstoken_app,
+        mock_obtain_accesstoken_cert,
+        mock_obtain_accesstoken_interactive,
+    ):
+        """The auth params should be returned."""
+        with patch.dict(
+            "os.environ",
+            {
+                "CLIENT_ID": "test",
+                "TENANT_NAME": "test",
+                "KEY_FILE": "test",
+                "THUMBPRINT": "test",
+            },
+        ):
+            result = getAuth(
+                None, localauth=None, certauth=True, interactiveauth=None, tenant=None
+            )
+            self.assertEqual(result, "token")
+
+    def test_get_auth_cert_missing_env(
+        self,
+        mock_getAuth,
+        mock_obtain_accesstoken_app,
+        mock_obtain_accesstoken_cert,
+        mock_obtain_accesstoken_interactive,
+    ):
+        """The auth params should be returned."""
+        with patch.dict(
+            "os.environ",
+            {"CLIENT_ID": "test", "TENANT_NAME": "test", "KEY_FILE": "test"},
+        ):
+
+            with self.assertRaises(Exception):
+                getAuth(
+                    None,
+                    localauth=None,
+                    certauth=True,
+                    interactiveauth=None,
+                    tenant=None,
+                )
+
+    def test_get_auth_interactive(
+        self,
+        mock_getAuth,
+        mock_obtain_accesstoken_app,
+        mock_obtain_accesstoken_cert,
+        mock_obtain_accesstoken_interactive,
+    ):
+        """The auth params should be returned."""
+        with patch.dict(
+            "os.environ",
+            {
+                "CLIENT_ID": "test",
+                "TENANT_NAME": "test",
+                "KEY_FILE": "test",
+                "THUMBPRINT": "test",
+            },
+        ):
+            result = getAuth(
+                None, localauth=None, certauth=None, interactiveauth=True, tenant=None
+            )
+            self.assertEqual(result, "token")
+
+    def test_get_auth_interactive_missing_env(
+        self,
+        mock_getAuth,
+        mock_obtain_accesstoken_app,
+        mock_obtain_accesstoken_cert,
+        mock_obtain_accesstoken_interactive,
+    ):
+        """The auth params should be returned."""
+        with patch.dict(
+            "os.environ",
+            {"CLIENT_ID": "test"},
+        ):
+
+            with self.assertRaises(Exception):
+                getAuth(
+                    None,
+                    localauth=None,
+                    certauth=None,
+                    interactiveauth=True,
+                    tenant=None,
+                )
 
 
 if __name__ == "__main__":

--- a/tests/test_graph_request.py
+++ b/tests/test_graph_request.py
@@ -34,7 +34,7 @@ class TestGraphRequestGet(unittest.TestCase):
     """Test class for graph_request."""
 
     def setUp(self):
-        self.token = {"accessToken": "token"}
+        self.token = {"access_token": "token"}
 
     def test_makeapirequest_status_429_no_q_param(self, mock_sleep, mock_get, mock_makeapirequest):
         """The request should be made once and exception should be raised."""
@@ -166,7 +166,7 @@ class TestGraphRequestGet(unittest.TestCase):
 @patch("requests.patch")
 class TestGraphRequestPatch(unittest.TestCase):
     def setUp(self):
-        self.token = {"accessToken": "token"}
+        self.token = {"access_token": "token"}
 
     def test_makeapirequestPatch_no_q_param(self, mock_patch, mock_makeapirequestPatch):
         """The request should be made and the response should be returned."""
@@ -201,7 +201,7 @@ class TestGraphRequestPatch(unittest.TestCase):
 @patch("time.sleep", return_value=None)
 class TestGraphRequestPost(unittest.TestCase):
     def setUp(self):
-        self.token = {"accessToken": "token"}
+        self.token = {"access_token": "token"}
         self.jdata = {"id": "0"}
         self.content = '{"id": "0"}'
         self.expected_result = {"id": "0"}
@@ -255,7 +255,7 @@ class TestGraphRequestPost(unittest.TestCase):
 @patch("requests.put")
 class TestGraphRequestPut(unittest.TestCase):
     def setUp(self):
-        self.token = {"accessToken": "token"}
+        self.token = {"access_token": "token"}
 
     def test_makeapirequestPut_no_q_param(self, mock_patch, mock_makeapirequestPut):
         """The request should be made and the response should be returned."""


### PR DESCRIPTION
The authentication module has been updated to MSAL, which replaces the deprecated ADAL library. This update brings additional authentication options, including Client Credentials and Certificate-based authentication.

- **Client Credentials:** This method utilizes the `CLIENT_ID` and `CLIENT_SECRET` to authenticate.

- **Certificate-based Authentication:** You can use a certificate uploaded to your Azure AD App Registration by adding the `-c` parameter. Additionally, you must set the environment variables `KEY_FILE` and `THUMBPRINT` to specify the path to the private key of the certificate and the thumbprint of the certificate, respectively. When using this option, **do not** specify the `-m` parameter.

- **Interactive Authentication:** If you are running the tool interactively and wish to authenticate with your own account, add the `-i` parameter. This will open a browser window prompting you to authenticate. When using this option, **do not** specify the `-m` parameter.