### PR TITLE
v1.3.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 1.3.3
+version = 1.3.4
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/src/IntuneCD/update_groupPolicyConfiguration.py
+++ b/src/IntuneCD/update_groupPolicyConfiguration.py
@@ -439,7 +439,7 @@ def update(path, token, assignment=False, report=False):
                 )
 
                 # If any differences were found on the profile, push them to Intune
-                if profile_diff:
+                if profile_diff and report is False:
                     request_data = json.dumps(
                         {
                             "displayName": repo_data["displayName"],

--- a/src/IntuneCD/update_windowsEnrollmentProfile.py
+++ b/src/IntuneCD/update_windowsEnrollmentProfile.py
@@ -71,7 +71,7 @@ def update(path, token, assignment=False, report=False):
                     print("-" * 90)
                     mem_id = data["value"]["id"]
                     # Remove keys before using DeepDiff
-                    mem_data["value"][0] = remove_keys(mem_data["value"][0])
+                    data["value"] = remove_keys(data["value"])
 
                     diff = DeepDiff(data["value"], repo_data, ignore_order=True).get(
                         "values_changed", {}


### PR DESCRIPTION
- Added missing check if running in report mode when updating administrative templates profiles information.
- When updating multiple Windows enrollment profiles, the ID of the first profile in the list was incorrectly removed causing the script to exit with `KeyError: 'id'`. This is now fixed so it removes the ID from the current Windows enrollment profile.