### PR TITLE
Bug fix - update group not included 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 1.4.0
+version = 1.4.1
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/src/IntuneCD/run_update.py
+++ b/src/IntuneCD/run_update.py
@@ -259,7 +259,9 @@ def start():
         if args.frontend:
             old_stdout = sys.stdout
             sys.stdout = feedstdout = StringIO()
-            summary = run_update(args.path, token, args.u, exclude, args.report)
+            summary = run_update(
+                args.path, token, args.u, exclude, args.report, args.create_groups
+            )
             sys.stdout = old_stdout
             feed_bytes = feedstdout.getvalue().encode("utf-8")
             out = base64.b64encode(feed_bytes).decode("utf-8")


### PR DESCRIPTION
When running the update with `-f`, --create-groups arg was not included causing the run to fail with `missing 1 required positional argument`.