### PR TITLE
v1.5.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 1.4.9
+version = 1.5.0
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/src/IntuneCD/backup_configurationPolicies.py
+++ b/src/IntuneCD/backup_configurationPolicies.py
@@ -37,12 +37,8 @@ def savebackup(path, output, exclude, token):
     for policy in policies["value"]:
         policy_ids.append(policy["id"])
 
-    assignment_responses = batch_assignment(
-        policies, "deviceManagement/configurationPolicies/", "/assignments", token
-    )
-    policy_settings_batch = batch_request(
-        policy_ids, "deviceManagement/configurationPolicies/", "/settings", token
-    )
+    assignment_responses = batch_assignment(policies, "deviceManagement/configurationPolicies/", "/assignments", token)
+    policy_settings_batch = batch_request(policy_ids, "deviceManagement/configurationPolicies/", "/settings", token)
 
     for policy in policies["value"]:
         results["config_count"] += 1
@@ -62,7 +58,8 @@ def savebackup(path, output, exclude, token):
         policy = remove_keys(policy)
 
         # Get filename without illegal characters
-        fname = clean_filename(name)
+        # fname = clean_filename(name)
+        fname = clean_filename(f"{name}_{str(policy['technologies']).split(',')[-1]}")
         # Save Configuration Policy as JSON or YAML depending on configured
         # value in "-o"
         save_output(output, configpath, fname, policy)

--- a/tests/Backup/test_backup_configurationPolicies.py
+++ b/tests/Backup/test_backup_configurationPolicies.py
@@ -44,12 +44,13 @@ class TestBackupConfigurationPolicy(unittest.TestCase):
         self.directory.create()
         self.token = "token"
         self.exclude = []
-        self.saved_path = f"{self.directory.path}/Settings Catalog/test."
+        self.saved_path = f"{self.directory.path}/Settings Catalog/test_test."
         self.expected_data = {
             "@odata.type": "#microsoft.graph.deviceManagementConfigurationPolicy",
             "assignments": [{"target": {"groupName": "Group1"}}],
             "description": "Description value",
             "name": "test",
+            "technologies": "test",
             "roleScopeTagIds": ["Role Scope Tag Ids value"],
             "settings": [
                 {
@@ -77,6 +78,7 @@ class TestBackupConfigurationPolicy(unittest.TestCase):
                     "@odata.type": "#microsoft.graph.deviceManagementConfigurationPolicy",
                     "id": "0",
                     "name": "test",
+                    "technologies": "test",
                     "description": "Description value",
                     "roleScopeTagIds": ["Role Scope Tag Ids value"],
                     "isAssigned": True,
@@ -88,27 +90,19 @@ class TestBackupConfigurationPolicy(unittest.TestCase):
             ]
         }
 
-        self.batch_assignment_patch = patch(
-            "src.IntuneCD.backup_configurationPolicies.batch_assignment"
-        )
+        self.batch_assignment_patch = patch("src.IntuneCD.backup_configurationPolicies.batch_assignment")
         self.batch_assignment = self.batch_assignment_patch.start()
         self.batch_assignment.return_value = BATCH_ASSIGNMENT
 
-        self.batch_request_patch = patch(
-            "src.IntuneCD.backup_configurationPolicies.batch_request"
-        )
+        self.batch_request_patch = patch("src.IntuneCD.backup_configurationPolicies.batch_request")
         self.batch_request = self.batch_request_patch.start()
         self.batch_request.return_value = BATCH_REQUEST
 
-        self.object_assignment_patch = patch(
-            "src.IntuneCD.backup_configurationPolicies.get_object_assignment"
-        )
+        self.object_assignment_patch = patch("src.IntuneCD.backup_configurationPolicies.get_object_assignment")
         self.object_assignment = self.object_assignment_patch.start()
         self.object_assignment.return_value = OBJECT_ASSIGNMENT
 
-        self.makeapirequest_patch = patch(
-            "src.IntuneCD.backup_configurationPolicies.makeapirequest"
-        )
+        self.makeapirequest_patch = patch("src.IntuneCD.backup_configurationPolicies.makeapirequest")
         self.makeapirequest = self.makeapirequest_patch.start()
         self.makeapirequest.return_value = self.configuration_policy
 

--- a/tests/Update/test_update_configurationPolicies.py
+++ b/tests/Update/test_update_configurationPolicies.py
@@ -16,9 +16,7 @@ class TestUpdateConfigurationPolicies(unittest.TestCase):
         self.directory = TempDirectory()
         self.directory.create()
         self.directory.makedir("Settings Catalog")
-        self.directory.write(
-            "Settings Catalog/test.json", '{"test": "test"}', encoding="utf-8"
-        )
+        self.directory.write("Settings Catalog/test.json", '{"test": "test"}', encoding="utf-8")
         self.directory.write("Settings Catalog/test.txt", "txt", encoding="utf-8")
         self.token = "token"
         self.mem_data = {
@@ -27,6 +25,7 @@ class TestUpdateConfigurationPolicies(unittest.TestCase):
                     "@odata.type": "test",
                     "id": "0",
                     "name": "test",
+                    "technologies": "test",
                     "testvalue": "test",
                     "settings": [{"id": "0", "testvalue": "test"}],
                     "assignments": [{"target": {"groupId": "test"}}],
@@ -45,57 +44,40 @@ class TestUpdateConfigurationPolicies(unittest.TestCase):
             "@odata.type": "test",
             "id": "0",
             "name": "test",
+            "technologies": "test",
             "testvalue": "test1",
             "settings": [{"id": "0", "testvalue": "test1"}],
             "assignments": [{"target": {"groupName": "test1"}}],
         }
 
-        self.batch_assignment_patch = patch(
-            "src.IntuneCD.update_configurationPolicies.batch_assignment"
-        )
+        self.batch_assignment_patch = patch("src.IntuneCD.update_configurationPolicies.batch_assignment")
         self.batch_assignment = self.batch_assignment_patch.start()
 
-        self.object_assignment_patch = patch(
-            "src.IntuneCD.update_configurationPolicies.get_object_assignment"
-        )
+        self.object_assignment_patch = patch("src.IntuneCD.update_configurationPolicies.get_object_assignment")
         self.object_assignment = self.object_assignment_patch.start()
 
-        self.makeapirequest_patch = patch(
-            "src.IntuneCD.update_configurationPolicies.makeapirequest"
-        )
+        self.makeapirequest_patch = patch("src.IntuneCD.update_configurationPolicies.makeapirequest")
         self.makeapirequest = self.makeapirequest_patch.start()
         self.makeapirequest.return_value = self.mem_data
 
-        self.update_assignment_patch = patch(
-            "src.IntuneCD.update_configurationPolicies.update_assignment"
-        )
+        self.update_assignment_patch = patch("src.IntuneCD.update_configurationPolicies.update_assignment")
         self.update_assignment = self.update_assignment_patch.start()
 
-        self.load_file_patch = patch(
-            "src.IntuneCD.update_configurationPolicies.load_file"
-        )
+        self.load_file_patch = patch("src.IntuneCD.update_configurationPolicies.load_file")
         self.load_file = self.load_file_patch.start()
         self.load_file.return_value = self.repo_data
 
-        self.post_assignment_update_patch = patch(
-            "src.IntuneCD.update_configurationPolicies.post_assignment_update"
-        )
+        self.post_assignment_update_patch = patch("src.IntuneCD.update_configurationPolicies.post_assignment_update")
         self.post_assignment_update = self.post_assignment_update_patch.start()
 
-        self.makeapirequestPatch_patch = patch(
-            "src.IntuneCD.update_configurationPolicies.makeapirequestPut"
-        )
+        self.makeapirequestPatch_patch = patch("src.IntuneCD.update_configurationPolicies.makeapirequestPut")
         self.makeapirequestPatch = self.makeapirequestPatch_patch.start()
 
-        self.makeapirequestPost_patch = patch(
-            "src.IntuneCD.update_configurationPolicies.makeapirequestPost"
-        )
+        self.makeapirequestPost_patch = patch("src.IntuneCD.update_configurationPolicies.makeapirequestPost")
         self.makeapirequestPost = self.makeapirequestPost_patch.start()
         self.makeapirequestPost.return_value = {"id": "0"}
 
-        self.makeapirequestDelete_patch = patch(
-            "src.IntuneCD.update_configurationPolicies.makeapirequestDelete"
-        )
+        self.makeapirequestDelete_patch = patch("src.IntuneCD.update_configurationPolicies.makeapirequestDelete")
         self.makeapirequestDelete = self.makeapirequestDelete_patch.start()
 
     def tearDown(self):
@@ -113,9 +95,7 @@ class TestUpdateConfigurationPolicies(unittest.TestCase):
     def test_update_with_diffs_and_assignment(self):
         """The count should be 1 and the post_assignment_update and makeapirequestPatch should be called."""
 
-        self.count = update(
-            self.directory.path, self.token, assignment=True, remove=True
-        )
+        self.count = update(self.directory.path, self.token, assignment=True, remove=True)
 
         self.assertEqual(self.count[0].count, 1)
         self.assertEqual(self.makeapirequestPatch.call_count, 1)
@@ -124,9 +104,7 @@ class TestUpdateConfigurationPolicies(unittest.TestCase):
     def test_update_with_diffs_no_assignment(self):
         """The count should be 1 and the makeapirequestPatch should be called."""
 
-        self.count = update(
-            self.directory.path, self.token, assignment=False, remove=True
-        )
+        self.count = update(self.directory.path, self.token, assignment=False, remove=True)
 
         self.assertEqual(self.count[0].count, 1)
         self.assertEqual(self.makeapirequestPatch.call_count, 1)
@@ -139,9 +117,7 @@ class TestUpdateConfigurationPolicies(unittest.TestCase):
         self.mem_data["value"][0]["testvalue"] = "test1"
         self.mem_data["value"].remove(self.mem_data["value"][1])
 
-        self.count = update(
-            self.directory.path, self.token, assignment=True, remove=True
-        )
+        self.count = update(self.directory.path, self.token, assignment=True, remove=True)
 
         self.assertEqual(self.count[0].count, 0)
         self.assertEqual(self.makeapirequestPatch.call_count, 0)
@@ -153,9 +129,7 @@ class TestUpdateConfigurationPolicies(unittest.TestCase):
         self.mem_data["value"][0]["testvalue"] = "test1"
         self.mem_data["value"].remove(self.mem_data["value"][1])
 
-        self.count = update(
-            self.directory.path, self.token, assignment=False, remove=True
-        )
+        self.count = update(self.directory.path, self.token, assignment=False, remove=True)
 
         self.assertEqual(self.count[0].count, 0)
         self.assertEqual(self.makeapirequestPatch.call_count, 0)
@@ -166,9 +140,7 @@ class TestUpdateConfigurationPolicies(unittest.TestCase):
 
         self.mem_data["value"][0]["name"] = "test1"
 
-        self.count = update(
-            self.directory.path, self.token, assignment=True, remove=True
-        )
+        self.count = update(self.directory.path, self.token, assignment=True, remove=True)
 
         self.assertEqual(self.count, [])
         self.assertEqual(self.makeapirequestPost.call_count, 1)
@@ -177,13 +149,9 @@ class TestUpdateConfigurationPolicies(unittest.TestCase):
     def test_update_skip_edr(self):
         """The count should be 0 as EDR is currently not supported"""
 
-        self.repo_data["templateReference"] = {
-            "templateDisplayName": "Endpoint detection and response"
-        }
+        self.repo_data["templateReference"] = {"templateDisplayName": "Endpoint detection and response"}
 
-        self.count = update(
-            self.directory.path, self.token, assignment=False, remove=True
-        )
+        self.count = update(self.directory.path, self.token, assignment=False, remove=True)
 
         self.assertEqual(self.count, [])
         self.assertEqual(self.makeapirequestPatch.call_count, 0)


### PR DESCRIPTION
Bug fixes:
- App Protection type "windowsInformationProtectionPolicy" failed to update due to incorrect response code
- If a settings catalog policy and Endpoint Security policy had the same name, one policy was overwritten in the backup. This has been changed so the `technology` is appended to the file name to avoid override errors.

closes #123 