### PR TITLE
v1.5.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 1.5.0
+version = 1.5.1
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/src/IntuneCD/backup_configurationPolicies.py
+++ b/src/IntuneCD/backup_configurationPolicies.py
@@ -38,7 +38,7 @@ def savebackup(path, output, exclude, token):
         policy_ids.append(policy["id"])
 
     assignment_responses = batch_assignment(policies, "deviceManagement/configurationPolicies/", "/assignments", token)
-    policy_settings_batch = batch_request(policy_ids, "deviceManagement/configurationPolicies/", "/settings", token)
+    policy_settings_batch = batch_request(policy_ids, "deviceManagement/configurationPolicies/", "/settings?&top=1000", token)
 
     for policy in policies["value"]:
         results["config_count"] += 1

--- a/src/IntuneCD/graph_request.py
+++ b/src/IntuneCD/graph_request.py
@@ -26,39 +26,23 @@ def makeapirequest(endpoint, token, q_param=None):
 
     if q_param is not None:
         response = requests.get(endpoint, headers=headers, params=q_param)
-        if (
-            response.status_code == 504
-            or response.status_code == 502
-            or response.status_code == 503
-        ):
-            print(
-                "Ran into issues with Graph request, waiting 10 seconds and trying again..."
-            )
+        if response.status_code == 504 or response.status_code == 502 or response.status_code == 503:
+            print("Ran into issues with Graph request, waiting 10 seconds and trying again...")
             time.sleep(10)
             response = requests.get(endpoint, headers=headers)
         elif response.status_code == 429:
-            print(
-                f"Hit Graph throttling, trying again after {response.headers['Retry-After']} seconds"
-            )
+            print(f"Hit Graph throttling, trying again after {response.headers['Retry-After']} seconds")
             while response.status_code == 429:
                 time.sleep(int(response.headers["Retry-After"]))
                 response = requests.get(endpoint, headers=headers)
     else:
         response = requests.get(endpoint, headers=headers)
-        if (
-            response.status_code == 504
-            or response.status_code == 502
-            or response.status_code == 503
-        ):
-            print(
-                "Ran into issues with Graph request, waiting 10 seconds and trying again..."
-            )
+        if response.status_code == 504 or response.status_code == 502 or response.status_code == 503:
+            print("Ran into issues with Graph request, waiting 10 seconds and trying again...")
             time.sleep(10)
             response = requests.get(endpoint, headers=headers)
         elif response.status_code == 429:
-            print(
-                f"Hit Graph throttling, trying again after {response.headers['Retry-After']} seconds"
-            )
+            print(f"Hit Graph throttling, trying again after {response.headers['Retry-After']} seconds")
             while response.status_code == 429:
                 time.sleep(int(response.headers["Retry-After"]))
                 response = requests.get(endpoint, headers=headers)
@@ -81,14 +65,10 @@ def makeapirequest(endpoint, token, q_param=None):
     elif ("assignmentFilters" in endpoint) and ("FeatureNotEnabled" in response.text):
         print("Assignment filters not enabled in tenant, skipping")
     else:
-        raise Exception(
-            "Request failed with ", response.status_code, " - ", response.text
-        )
+        raise Exception("Request failed with ", response.status_code, " - ", response.text)
 
 
-def makeapirequestPatch(
-    patchEndpoint, token, q_param=None, jdata=None, status_code=200
-):
+def makeapirequestPatch(patchEndpoint, token, q_param=None, jdata=None, status_code=200):
     """
     This function makes a PATCH request to the Microsoft Graph API.
 
@@ -105,22 +85,16 @@ def makeapirequestPatch(
     }
 
     if q_param is not None:
-        response = requests.patch(
-            patchEndpoint, headers=headers, params=q_param, data=jdata
-        )
+        response = requests.patch(patchEndpoint, headers=headers, params=q_param, data=jdata)
     else:
         response = requests.patch(patchEndpoint, headers=headers, data=jdata)
     if response.status_code == status_code:
         pass
     else:
-        raise Exception(
-            "Request failed with ", response.status_code, " - ", response.text
-        )
+        raise Exception("Request failed with ", response.status_code, " - ", response.text)
 
 
-def makeapirequestDelete(
-    deleteEndpoint, token, q_param=None, jdata=None, status_code=200
-):
+def makeapirequestDelete(deleteEndpoint, token, q_param=None, jdata=None, status_code=200):
     """
     This function makes a DELETE request to the Microsoft Graph API.
 
@@ -137,17 +111,13 @@ def makeapirequestDelete(
     }
 
     if q_param is not None:
-        response = requests.delete(
-            deleteEndpoint, headers=headers, params=q_param, data=jdata
-        )
+        response = requests.delete(deleteEndpoint, headers=headers, params=q_param, data=jdata)
     else:
         response = requests.delete(deleteEndpoint, headers=headers, data=jdata)
     if response.status_code == status_code:
         pass
     else:
-        raise Exception(
-            "Request failed with ", response.status_code, " - ", response.text
-        )
+        raise Exception("Request failed with ", response.status_code, " - ", response.text)
 
 
 def makeapirequestPost(patchEndpoint, token, q_param=None, jdata=None, status_code=200):
@@ -167,9 +137,7 @@ def makeapirequestPost(patchEndpoint, token, q_param=None, jdata=None, status_co
     }
 
     if q_param is not None:
-        response = requests.post(
-            patchEndpoint, headers=headers, params=q_param, data=jdata
-        )
+        response = requests.post(patchEndpoint, headers=headers, params=q_param, data=jdata)
     else:
         response = requests.post(patchEndpoint, headers=headers, data=jdata)
     if response.status_code == status_code:
@@ -178,17 +146,17 @@ def makeapirequestPost(patchEndpoint, token, q_param=None, jdata=None, status_co
             return json_data
         else:
             pass
+    elif response.status_code == 504:
+        print("Ran into issues with Graph request, waiting 10 seconds and trying again...")
+        time.sleep(10)
+        response = requests.post(patchEndpoint, headers=headers, data=jdata)
     elif response.status_code == 429:
-        print(
-            f"Hit Graph throttling, trying again after {response.headers['Retry-After']} seconds"
-        )
+        print(f"Hit Graph throttling, trying again after {response.headers['Retry-After']} seconds")
         while response.status_code == 429:
             time.sleep(int(response.headers["Retry-After"]))
             response = requests.post(patchEndpoint, headers=headers, data=jdata)
     else:
-        raise Exception(
-            "Request failed with ", response.status_code, " - ", response.text
-        )
+        raise Exception("Request failed with ", response.status_code, " - ", response.text)
 
 
 def makeapirequestPut(patchEndpoint, token, q_param=None, jdata=None, status_code=200):
@@ -208,14 +176,10 @@ def makeapirequestPut(patchEndpoint, token, q_param=None, jdata=None, status_cod
     }
 
     if q_param is not None:
-        response = requests.put(
-            patchEndpoint, headers=headers, params=q_param, data=jdata
-        )
+        response = requests.put(patchEndpoint, headers=headers, params=q_param, data=jdata)
     else:
         response = requests.put(patchEndpoint, headers=headers, data=jdata)
     if response.status_code == status_code:
         pass
     else:
-        raise Exception(
-            "Request failed with ", response.status_code, " - ", response.text
-        )
+        raise Exception("Request failed with ", response.status_code, " - ", response.text)

--- a/tests/test_graph_request.py
+++ b/tests/test_graph_request.py
@@ -49,9 +49,7 @@ class TestGraphRequestGet(unittest.TestCase):
     def setUp(self):
         self.token = {"access_token": "token"}
 
-    def test_makeapirequest_status_429_no_q_param(
-        self, mock_sleep, mock_get, mock_makeapirequest
-    ):
+    def test_makeapirequest_status_429_no_q_param(self, mock_sleep, mock_get, mock_makeapirequest):
         """The request should be made once and exception should be raised."""
         with self.assertRaises(Exception):
             self.mock_resp = _mock_response(
@@ -66,9 +64,7 @@ class TestGraphRequestGet(unittest.TestCase):
 
         self.assertEqual(2, mock_get.call_count)
 
-    def test_makeapirequest_status_429_with_q_param(
-        self, mock_sleep, mock_get, mock_makeapirequest
-    ):
+    def test_makeapirequest_status_429_with_q_param(self, mock_sleep, mock_get, mock_makeapirequest):
         """The request should be made once and exception should be raised."""
         with self.assertRaises(Exception):
             self.mock_resp = _mock_response(
@@ -85,16 +81,12 @@ class TestGraphRequestGet(unittest.TestCase):
 
     def test_makeapirequest_no_q_param(self, mock_sleep, mock_get, mock_makeapirequest):
         """The request should be made once and the response should be returned."""
-        self.mock_resp = _mock_response(
-            self, status=200, content='{"value": [{"id": "0"}]}'
-        )
+        self.mock_resp = _mock_response(self, status=200, content='{"value": [{"id": "0"}]}')
         mock_get.return_value = self.mock_resp
         self.result = makeapirequest("https://endpoint", self.token)
         self.assertEqual(self.result, {"value": [{"id": "0"}]})
 
-    def test_makeapirequest_status_502_no_q_param(
-        self, mock_sleep, mock_get, mock_makeapirequest
-    ):
+    def test_makeapirequest_status_502_no_q_param(self, mock_sleep, mock_get, mock_makeapirequest):
         """The request should be made twice and exception should be raised."""
         with self.assertRaises(Exception):
             self.mock_resp = _mock_response(self, status=502, content="request timeout")
@@ -103,9 +95,7 @@ class TestGraphRequestGet(unittest.TestCase):
 
         self.assertEqual(2, mock_get.call_count)
 
-    def test_makeapirequest_status_503_no_q_param(
-        self, mock_sleep, mock_get, mock_makeapirequest
-    ):
+    def test_makeapirequest_status_503_no_q_param(self, mock_sleep, mock_get, mock_makeapirequest):
         """The request should be made twice and exception should be raised."""
         with self.assertRaises(Exception):
             self.mock_resp = _mock_response(self, status=503, content="request timeout")
@@ -114,9 +104,7 @@ class TestGraphRequestGet(unittest.TestCase):
 
         self.assertEqual(2, mock_get.call_count)
 
-    def test_makeapirequest_status_504_no_q_param(
-        self, mock_sleep, mock_get, mock_makeapirequest
-    ):
+    def test_makeapirequest_status_504_no_q_param(self, mock_sleep, mock_get, mock_makeapirequest):
         """The request should be made twice and exception should be raised."""
         with self.assertRaises(Exception):
             self.mock_resp = _mock_response(self, status=504, content="request timeout")
@@ -125,22 +113,14 @@ class TestGraphRequestGet(unittest.TestCase):
 
         self.assertEqual(2, mock_get.call_count)
 
-    def test_makeapirequest_with_q_param(
-        self, mock_sleep, mock_get, mock_makeapirequest
-    ):
+    def test_makeapirequest_with_q_param(self, mock_sleep, mock_get, mock_makeapirequest):
         """The request should be made once and the response should be returned."""
-        self.mock_resp = _mock_response(
-            self, status=200, content='{"value": [{"id": "0"}]}'
-        )
+        self.mock_resp = _mock_response(self, status=200, content='{"value": [{"id": "0"}]}')
         mock_get.return_value = self.mock_resp
-        self.result = makeapirequest(
-            "https://endpoint", self.token, q_param="$filter=id eq '0'"
-        )
+        self.result = makeapirequest("https://endpoint", self.token, q_param="$filter=id eq '0'")
         self.assertEqual(self.result, {"value": [{"id": "0"}]})
 
-    def test_makeapirequest_status_502_with_q_param(
-        self, mock_sleep, mock_get, mock_makeapirequest
-    ):
+    def test_makeapirequest_status_502_with_q_param(self, mock_sleep, mock_get, mock_makeapirequest):
         """The request should be made twice and exception should be raised."""
         with self.assertRaises(Exception):
             self.mock_resp = _mock_response(self, status=502, content="request timeout")
@@ -149,9 +129,7 @@ class TestGraphRequestGet(unittest.TestCase):
 
         self.assertEqual(2, mock_get.call_count)
 
-    def test_makeapirequest_status_503_with_q_param(
-        self, mock_sleep, mock_get, mock_makeapirequest
-    ):
+    def test_makeapirequest_status_503_with_q_param(self, mock_sleep, mock_get, mock_makeapirequest):
         """The request should be made twice and exception should be raised."""
         with self.assertRaises(Exception):
             self.mock_resp = _mock_response(self, status=503, content="request timeout")
@@ -160,9 +138,7 @@ class TestGraphRequestGet(unittest.TestCase):
 
         self.assertEqual(2, mock_get.call_count)
 
-    def test_makeapirequest_status_504_with_q_param(
-        self, mock_sleep, mock_get, mock_makeapirequest
-    ):
+    def test_makeapirequest_status_504_with_q_param(self, mock_sleep, mock_get, mock_makeapirequest):
         """The request should be made twice and exception should be raised."""
         with self.assertRaises(Exception):
             self.mock_resp = _mock_response(self, status=504, content="request timeout")
@@ -171,9 +147,7 @@ class TestGraphRequestGet(unittest.TestCase):
 
         self.assertEqual(2, mock_get.call_count)
 
-    def test_makeapirequest_odata_nextlink(
-        self, mock_sleep, mock_get, mock_makeapirequest
-    ):
+    def test_makeapirequest_odata_nextlink(self, mock_sleep, mock_get, mock_makeapirequest):
         """The request should be made and the response should contain next link values."""
         self.NEXT_LINK_VALUE = {"value": [{"id": "1"}]}
         mock_makeapirequest.return_value = self.NEXT_LINK_VALUE
@@ -195,13 +169,9 @@ class TestGraphRequestGet(unittest.TestCase):
 
         self.assertEqual(1, mock_get.call_count)
 
-    def test_makeapirequest_assignmentfilter_not_enabled(
-        self, mock_sleep, mock_get, mock_makeapirequest
-    ):
+    def test_makeapirequest_assignmentfilter_not_enabled(self, mock_sleep, mock_get, mock_makeapirequest):
         """The request should be made and assignment filters should be skipped."""
-        self.mock_resp = _mock_response(
-            self, status=500, content='{"FeatureNotEnabled": []}'
-        )
+        self.mock_resp = _mock_response(self, status=500, content='{"FeatureNotEnabled": []}')
         mock_get.return_value = self.mock_resp
         makeapirequest("https://endpoint/assignmentFilters", self.token)
 
@@ -210,9 +180,7 @@ class TestGraphRequestGet(unittest.TestCase):
     def test_makeapirequest_exception(self, mock_sleep, mock_get, mock_makeapirequest):
         """The request should be made and exception should be raised."""
         with self.assertRaises(Exception):
-            self.mock_resp = _mock_response(
-                self, status=500, content="Internal Server Error"
-            )
+            self.mock_resp = _mock_response(self, status=500, content="Internal Server Error")
             mock_get.return_value = self.mock_resp
             makeapirequest("https://endpoint/", self.token)
 
@@ -229,15 +197,11 @@ class TestGraphRequestPatch(unittest.TestCase):
         """The request should be made and the response should be returned."""
         self.mock_resp = _mock_response(self, status=200, content="")
         mock_patch.return_value = self.mock_resp
-        result = makeapirequestPatch(
-            "https://endpoint", self.token, q_param=None, jdata='{"id": "0"}'
-        )
+        result = makeapirequestPatch("https://endpoint", self.token, q_param=None, jdata='{"id": "0"}')
 
         self.assertEqual(result, None)
 
-    def test_makeapirequestPatch_with_q_param(
-        self, mock_patch, mock_makeapirequestPatch
-    ):
+    def test_makeapirequestPatch_with_q_param(self, mock_patch, mock_makeapirequestPatch):
         """The request should be made and the response should be returned."""
         self.mock_resp = _mock_response(self, status=200, content="")
         mock_patch.return_value = self.mock_resp
@@ -250,9 +214,7 @@ class TestGraphRequestPatch(unittest.TestCase):
 
         self.assertEqual(self.result, None)
 
-    def test_makeapirequestPatch_not_matching_status_code(
-        self, mock_patch, mock_makeapirequestPatch
-    ):
+    def test_makeapirequestPatch_not_matching_status_code(self, mock_patch, mock_makeapirequestPatch):
         """The request should be made and the response should be returned."""
         with self.assertRaises(Exception):
             self.mock_resp = _mock_response(self, status=204, content="")
@@ -278,47 +240,42 @@ class TestGraphRequestPost(unittest.TestCase):
         self.content = '{"id": "0"}'
         self.expected_result = {"id": "0"}
 
-    def test_makeapirequestPost_status_429_no_q_param(
-        self, mock_sleep, mock_patch, mock_makeapirequestPost
-    ):
+    def test_makeapirequestPost_status_429_no_q_param(self, mock_sleep, mock_patch, mock_makeapirequestPost):
         """The request should be made twice."""
-        self.mock_resp = _mock_response(
-            self, status=429, content="Too Many equests", headers={"Retry-After": "10"}
-        )
+        self.mock_resp = _mock_response(self, status=429, content="Too Many equests", headers={"Retry-After": "10"})
         self.mock_resp2 = _mock_response(self, status=200, content="Success")
         mock_patch.side_effect = self.mock_resp, self.mock_resp2
         makeapirequestPost("https://endpoint", self.token)
 
         self.assertEqual(2, mock_patch.call_count)
 
-    def test_makeapirequestPost_status_429_with_q_param(
-        self, mock_sleep, mock_patch, mock_makeapirequestPost
-    ):
+    def test_makeapirequestPost_status_429_with_q_param(self, mock_sleep, mock_patch, mock_makeapirequestPost):
         """The request should be made twice."""
-        self.mock_resp = _mock_response(
-            self, status=429, content="Too Many Requests", headers={"Retry-After": "10"}
-        )
+        self.mock_resp = _mock_response(self, status=429, content="Too Many Requests", headers={"Retry-After": "10"})
         self.mock_resp2 = _mock_response(self, status=200, content="Success")
         mock_patch.side_effect = self.mock_resp, self.mock_resp2
         makeapirequestPost("https://endpoint", self.token, q_param="$filter=id eq '0'")
 
         self.assertEqual(2, mock_patch.call_count)
 
-    def test_makeapirequestPost_no_q_param(
-        self, mock_sleep, mock_patch, mock_makeapirequestPost
-    ):
+    def test_makeapirequestPost_status_504_no_q_param(self, mock_sleep, mock_patch, mock_makeapirequestPost):
+        """The request should be made twice."""
+        self.mock_resp = _mock_response(self, status=504, content="Error")
+        self.mock_resp2 = _mock_response(self, status=200, content="Success")
+        mock_patch.side_effect = self.mock_resp, self.mock_resp2
+        makeapirequestPost("https://endpoint", self.token)
+
+        self.assertEqual(2, mock_patch.call_count)
+
+    def test_makeapirequestPost_no_q_param(self, mock_sleep, mock_patch, mock_makeapirequestPost):
         """The request should be made and the response should be returned."""
         self.mock_resp = _mock_response(self, status=200, content=self.content)
         mock_patch.return_value = self.mock_resp
-        self.result = makeapirequestPost(
-            "https://endpoint", self.token, q_param=None, jdata=self.jdata
-        )
+        self.result = makeapirequestPost("https://endpoint", self.token, q_param=None, jdata=self.jdata)
 
         self.assertEqual(self.result, self.expected_result)
 
-    def test_makeapirequestPost_with_q_param(
-        self, mock_sleep, mock_patch, mock_makeapirequestPost
-    ):
+    def test_makeapirequestPost_with_q_param(self, mock_sleep, mock_patch, mock_makeapirequestPost):
         """The request should be made and the response should be returned."""
         self.mock_resp = _mock_response(self, status=200, content=self.content)
         mock_patch.return_value = self.mock_resp
@@ -331,9 +288,7 @@ class TestGraphRequestPost(unittest.TestCase):
 
         self.assertEqual(self.result, self.expected_result)
 
-    def test_makeapirequestPost_not_matching_status_code(
-        self, mock_sleep, mock_patch, mock_makeapirequestPost
-    ):
+    def test_makeapirequestPost_not_matching_status_code(self, mock_sleep, mock_patch, mock_makeapirequestPost):
         """The request should be made and the response should be returned."""
         with self.assertRaises(Exception):
             self.mock_resp = _mock_response(self, status=204, content="")
@@ -359,9 +314,7 @@ class TestGraphRequestPut(unittest.TestCase):
         """The request should be made and the response should be returned."""
         self.mock_resp = _mock_response(self, status=200, content="")
         mock_patch.return_value = self.mock_resp
-        self.result = makeapirequestPut(
-            "https://endpoint", self.token, q_param=None, jdata='{"id": "0"}'
-        )
+        self.result = makeapirequestPut("https://endpoint", self.token, q_param=None, jdata='{"id": "0"}')
 
         self.assertEqual(self.result, None)
 
@@ -378,9 +331,7 @@ class TestGraphRequestPut(unittest.TestCase):
 
         self.assertEqual(self.result, None)
 
-    def test_makeapirequestPut_not_matching_status_code(
-        self, mock_patch, mock_makeapirequestPut
-    ):
+    def test_makeapirequestPut_not_matching_status_code(self, mock_patch, mock_makeapirequestPut):
         """The request should be made and the response should be returned."""
         with self.assertRaises(Exception):
             self.mock_resp = _mock_response(self, status=204, content="")
@@ -402,21 +353,15 @@ class TestGraphRequestDelete(unittest.TestCase):
     def setUp(self):
         self.token = {"access_token": "token"}
 
-    def test_makeapirequestDelete_no_q_param(
-        self, mock_patch, mock_makeapirequestDelete
-    ):
+    def test_makeapirequestDelete_no_q_param(self, mock_patch, mock_makeapirequestDelete):
         """The request should be made and the response should be returned."""
         self.mock_resp = _mock_response(self, status=200, content="")
         mock_patch.return_value = self.mock_resp
-        self.result = makeapirequestDelete(
-            "https://endpoint", self.token, q_param=None, jdata='{"id": "0"}'
-        )
+        self.result = makeapirequestDelete("https://endpoint", self.token, q_param=None, jdata='{"id": "0"}')
 
         self.assertEqual(self.result, None)
 
-    def test_makeapirequestDelete_with_q_param(
-        self, mock_patch, mock_makeapirequestDelete
-    ):
+    def test_makeapirequestDelete_with_q_param(self, mock_patch, mock_makeapirequestDelete):
         """The request should be made and the response should be returned."""
         self.mock_resp = _mock_response(self, status=200, content="")
         mock_patch.return_value = self.mock_resp
@@ -429,9 +374,7 @@ class TestGraphRequestDelete(unittest.TestCase):
 
         self.assertEqual(self.result, None)
 
-    def test_makeapirequestDelete_not_matching_status_code(
-        self, mock_patch, mock_makeapirequestDelete
-    ):
+    def test_makeapirequestDelete_not_matching_status_code(self, mock_patch, mock_makeapirequestDelete):
         """The request should be made and the response should be returned."""
         with self.assertRaises(Exception):
             self.mock_resp = _mock_response(self, status=204, content="")


### PR DESCRIPTION
Bug fixes and stability improvements

## Bug fixes
- Only 25 settings were backed up in Settings Catalog configurations: closes #125 
- Exclude default device limit enrollment configuration from removal causing the run to fail

## Improvements
- Added a retry if the response code is `504` on a post request