### PR TITLE
Bug fix - incorrect assignment endpoint

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 2.0.0
+version = 2.0.1
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/src/IntuneCD/backup_windowsQualityUpdates.py
+++ b/src/IntuneCD/backup_windowsQualityUpdates.py
@@ -34,7 +34,7 @@ def savebackup(path, output, exclude, token, prefix):
 
     assignment_responses = batch_assignment(
         data,
-        "deviceManagement/windowsDriverUpdateProfiles/",
+        "deviceManagement/windowsQualityUpdateProfiles/",
         "/assignments",
         token,
     )


### PR DESCRIPTION
Windows Quality Profiles had an incorrect assignment endpoint causing assignments to not be backed up.