### PR TITLE
v2.0.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 2.0.2
+version = 2.0.3.beta1
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 2.0.3.beta1
+version = 2.0.3.beta2
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/src/IntuneCD/backup_AppProtection.py
+++ b/src/IntuneCD/backup_AppProtection.py
@@ -30,9 +30,7 @@ def savebackup(path, output, exclude, token, prefix, append_id):
     configpath = path + "/" + "App Protection/"
     data = makeapirequest(ENDPOINT, token)
 
-    assignment_responses = batch_assignment(
-        data, "deviceAppManagement/", "/assignments", token, app_protection=True
-    )
+    assignment_responses = batch_assignment(data, "deviceAppManagement/", "/assignments", token, app_protection=True)
 
     # If profile is ManagedAppConfiguration, skip to next
     for profile in data["value"]:
@@ -55,16 +53,12 @@ def savebackup(path, output, exclude, token, prefix, append_id):
         print("Backing up App Protection: " + profile["displayName"])
 
         if "targetedAppManagementLevels" in profile:
-            fname = clean_filename(
-                f"{profile['displayName']}_{profile['targetedAppManagementLevels']}"
-            )
+            fname = clean_filename(f"{profile['displayName']}_{profile['targetedAppManagementLevels']}")
         else:
-            fname = clean_filename(
-                f"{profile['displayName']}_{str(profile['@odata.type'].split('.')[2])}"
-            )
+            fname = clean_filename(f"{profile['displayName']}_{str(profile['@odata.type'].split('.')[2])}")
 
         if append_id:
-            fname = f"{fname}_{graph_id}"
+            fname = f"{fname}__{graph_id}"
 
         # Save App Protection as JSON or YAML depending on configured value in
         # "-o"

--- a/src/IntuneCD/backup_appConfiguration.py
+++ b/src/IntuneCD/backup_appConfiguration.py
@@ -15,9 +15,7 @@ from .remove_keys import remove_keys
 from .check_prefix import check_prefix_match
 
 # Set MS Graph endpoint
-ENDPOINT = (
-    "https://graph.microsoft.com/beta/deviceAppManagement/mobileAppConfigurations"
-)
+ENDPOINT = "https://graph.microsoft.com/beta/deviceAppManagement/mobileAppConfigurations"
 APP_ENDPOINT = "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps"
 
 
@@ -37,9 +35,7 @@ def savebackup(path, output, exclude, token, prefix, append_id):
     data = makeapirequest(ENDPOINT, token)
 
     if data["value"]:
-        assignment_responses = batch_assignment(
-            data, "deviceAppManagement/mobileAppConfigurations/", "/assignments", token
-        )
+        assignment_responses = batch_assignment(data, "deviceAppManagement/mobileAppConfigurations/", "/assignments", token)
 
         for profile in data["value"]:
             if prefix and not check_prefix_match(profile["displayName"], prefix):
@@ -68,9 +64,7 @@ def savebackup(path, output, exclude, token, prefix, append_id):
 
             if profile.get("payloadJson"):
                 try:
-                    profile["payloadJson"] = base64.b64decode(
-                        profile["payloadJson"]
-                    ).decode("utf-8")
+                    profile["payloadJson"] = base64.b64decode(profile["payloadJson"]).decode("utf-8")
                     profile["payloadJson"] = json.loads(profile["payloadJson"])
                 except Exception:
                     print("Unable to decode payloadJson for " + profile["displayName"])
@@ -78,11 +72,9 @@ def savebackup(path, output, exclude, token, prefix, append_id):
             print("Backing up App Configuration: " + profile["displayName"])
 
             # Get filename without illegal characters
-            fname = clean_filename(
-                f"{profile['displayName']}_{str(profile['@odata.type'].split('.')[2])}"
-            )
+            fname = clean_filename(f"{profile['displayName']}_{str(profile['@odata.type'].split('.')[2])}")
             if append_id:
-                fname = f"{fname}_{graph_id}"
+                fname = f"{fname}__{graph_id}"
             # Save App Configuration as JSON or YAML depending on configured value
             # in "-o"
             save_output(output, configpath, fname, profile)

--- a/src/IntuneCD/backup_appleEnrollmentProfile.py
+++ b/src/IntuneCD/backup_appleEnrollmentProfile.py
@@ -55,7 +55,7 @@ def savebackup(path, output, token, prefix, append_id):
                 # Get filename without illegal characters
                 fname = clean_filename(value["displayName"])
                 if append_id:
-                    fname = f"{fname}_{graph_id}"
+                    fname = f"{fname}__{graph_id}"
                 # Save Apple Enrollment Profile as JSON or YAML depending on
                 # configured value in "-o"
                 save_output(output, configpath, fname, value)

--- a/src/IntuneCD/backup_applications.py
+++ b/src/IntuneCD/backup_applications.py
@@ -74,7 +74,7 @@ def savebackup(path, output, exclude, token, append_id):
         # If app type is Win32 or MSI, add version to the name as multiple
         # versions can exist
         elif app["@odata.type"] == "#microsoft.graph.win32LobApp":
-            if app["displayVersion"] is None:
+            if not app["displayVersion"]:
                 app_name = app["displayName"] + "_Win32"
             else:
                 app_name = app["displayName"] + "_Win32_" + str(app["displayVersion"]).replace(".", "_")

--- a/src/IntuneCD/backup_applications.py
+++ b/src/IntuneCD/backup_applications.py
@@ -49,9 +49,7 @@ def savebackup(path, output, exclude, token, append_id):
     results = {"config_count": 0, "outputs": []}
 
     data = makeapirequest(ENDPOINT, token, q_param)
-    assignment_responses = batch_assignment(
-        data, "deviceAppManagement/mobileApps/", "/assignments", token
-    )
+    assignment_responses = batch_assignment(data, "deviceAppManagement/mobileApps/", "/assignments", token)
 
     for app in data["value"]:
         app_name = ""
@@ -70,34 +68,18 @@ def savebackup(path, output, exclude, token, append_id):
         # If app type is VPP, add Apple ID to the name as the app can exist
         # multiple times
         if app["@odata.type"] == "#microsoft.graph.iosVppApp":
-            app_name = (
-                app["displayName"]
-                + "_iOSVppApp_"
-                + str(app["vppTokenAppleId"].split("@")[0])
-            )
+            app_name = app["displayName"] + "_iOSVppApp_" + str(app["vppTokenAppleId"].split("@")[0])
         elif app["@odata.type"] == "#microsoft.graph.macOsVppApp":
-            app_name = (
-                app["displayName"]
-                + "_macOSVppApp_"
-                + str(app["vppTokenAppleId"].split("@")[0])
-            )
+            app_name = app["displayName"] + "_macOSVppApp_" + str(app["vppTokenAppleId"].split("@")[0])
         # If app type is Win32 or MSI, add version to the name as multiple
         # versions can exist
         elif app["@odata.type"] == "#microsoft.graph.win32LobApp":
             if app["displayVersion"] is None:
                 app_name = app["displayName"] + "_Win32"
             else:
-                app_name = (
-                    app["displayName"]
-                    + "_Win32_"
-                    + str(app["displayVersion"]).replace(".", "_")
-                )
+                app_name = app["displayName"] + "_Win32_" + str(app["displayVersion"]).replace(".", "_")
         elif app["@odata.type"] == "#microsoft.graph.windowsMobileMSI":
-            app_name = (
-                app["displayName"]
-                + "_WinMSI_"
-                + str(app["productVersion"]).replace(".", "_")
-            )
+            app_name = app["displayName"] + "_WinMSI_" + str(app["productVersion"]).replace(".", "_")
         # If app is not VPP, Win32 or MSI only add the app type to the name
         else:
             app_name = app["displayName"] + "_" + str(app["@odata.type"].split(".")[2])
@@ -127,7 +109,7 @@ def savebackup(path, output, exclude, token, append_id):
         # Get filename without illegal characters
         fname = clean_filename(app_name)
         if append_id:
-            fname = f"{fname}_{graph_id}"
+            fname = f"{fname}__{graph_id}"
 
         save_output(output, configpath, fname, app)
 

--- a/src/IntuneCD/backup_assignmentFilters.py
+++ b/src/IntuneCD/backup_assignmentFilters.py
@@ -41,7 +41,7 @@ def savebackup(path, output, token, prefix, append_id):
             # Get filename without illegal characters
             fname = clean_filename(assign_filter["displayName"])
             if append_id:
-                fname = f"{fname}_{graph_id}"
+                fname = f"{fname}__{graph_id}"
             # Save Filters as JSON or YAML depending on configured value in
             # "-o"
             save_output(output, configpath, fname, assign_filter)

--- a/src/IntuneCD/backup_compliance.py
+++ b/src/IntuneCD/backup_compliance.py
@@ -28,14 +28,10 @@ def savebackup(path, output, exclude, token, prefix, append_id):
 
     results = {"config_count": 0, "outputs": []}
     configpath = path + "/" + "Compliance Policies/Policies/"
-    q_param = {
-        "$expand": "scheduledActionsForRule($expand=scheduledActionConfigurations)"
-    }
+    q_param = {"$expand": "scheduledActionsForRule($expand=scheduledActionConfigurations)"}
     data = makeapirequest(ENDPOINT, token, q_param)
 
-    assignment_responses = batch_assignment(
-        data, "deviceManagement/deviceCompliancePolicies/", "/assignments", token
-    )
+    assignment_responses = batch_assignment(data, "deviceManagement/deviceCompliancePolicies/", "/assignments", token)
 
     for policy in data["value"]:
         if prefix and not check_prefix_match(policy["displayName"], prefix):
@@ -54,15 +50,13 @@ def savebackup(path, output, exclude, token, prefix, append_id):
         for rule in policy["scheduledActionsForRule"]:
             remove_keys(rule)
         if policy["scheduledActionsForRule"]:
-            for scheduled_config in policy["scheduledActionsForRule"][0][
-                "scheduledActionConfigurations"
-            ]:
+            for scheduled_config in policy["scheduledActionsForRule"][0]["scheduledActionConfigurations"]:
                 remove_keys(scheduled_config)
 
         # Get filename without illegal characters
         fname = clean_filename(policy["displayName"])
         if append_id:
-            fname = f"{fname}_{policy['@odata.type'].split('.')[2]}_{graph_id}"
+            fname = f"{fname}__{policy['@odata.type'].split('.')[2]}_{graph_id}"
         else:
             fname = f"{fname}_{policy['@odata.type'].split('.')[2]}"
         # Save Compliance policy as JSON or YAML depending on configured value

--- a/src/IntuneCD/backup_compliance.py
+++ b/src/IntuneCD/backup_compliance.py
@@ -56,7 +56,7 @@ def savebackup(path, output, exclude, token, prefix, append_id):
         # Get filename without illegal characters
         fname = clean_filename(policy["displayName"])
         if append_id:
-            fname = f"{fname}__{policy['@odata.type'].split('.')[2]}_{graph_id}"
+            fname = f"{fname}_{policy['@odata.type'].split('.')[2]}__{graph_id}"
         else:
             fname = f"{fname}_{policy['@odata.type'].split('.')[2]}"
         # Save Compliance policy as JSON or YAML depending on configured value

--- a/src/IntuneCD/backup_compliancePartner.py
+++ b/src/IntuneCD/backup_compliancePartner.py
@@ -10,9 +10,7 @@ from .save_output import save_output
 from .remove_keys import remove_keys
 
 # Set MS Graph endpoint
-ENDPOINT = (
-    "https://graph.microsoft.com/beta/deviceManagement/complianceManagementPartners"
-)
+ENDPOINT = "https://graph.microsoft.com/beta/deviceManagement/complianceManagementPartners"
 
 
 # Get all Compliance Partners and save them in specified path
@@ -42,7 +40,7 @@ def savebackup(path, output, token, append_id):
         # Get filename without illegal characters
         fname = clean_filename(partner["displayName"])
         if append_id:
-            fname = f"{fname}_{graph_id}"
+            fname = f"{fname}__{graph_id}"
         # Save Compliance policy as JSON or YAML depending on configured
         # value in "-o"
         save_output(output, configpath, fname, partner)

--- a/src/IntuneCD/backup_conditionalAccess.py
+++ b/src/IntuneCD/backup_conditionalAccess.py
@@ -38,9 +38,7 @@ def savebackup(path, output, token, prefix, append_id):
 
             policy = makeapirequest(f"{ENDPOINT}/{policy['id']}", token)
             if policy["grantControls"]:
-                policy["grantControls"].pop(
-                    "authenticationStrength@odata.context", None
-                )
+                policy["grantControls"].pop("authenticationStrength@odata.context", None)
 
             graph_id = policy["id"]
             policy = remove_keys(policy)
@@ -48,7 +46,7 @@ def savebackup(path, output, token, prefix, append_id):
             # Get filename without illegal characters
             fname = clean_filename(policy["displayName"])
             if append_id:
-                fname = f"{fname}_{graph_id}"
+                fname = f"{fname}__{graph_id}"
             # Save Conditional Access as JSON or YAML depending on configured
             # value in "-o"
             save_output(output, configpath, fname, policy)

--- a/src/IntuneCD/backup_configurationPolicies.py
+++ b/src/IntuneCD/backup_configurationPolicies.py
@@ -38,9 +38,7 @@ def savebackup(path, output, exclude, token, prefix, append_id):
     for policy in policies["value"]:
         policy_ids.append(policy["id"])
 
-    assignment_responses = batch_assignment(
-        policies, "deviceManagement/configurationPolicies/", "/assignments", token
-    )
+    assignment_responses = batch_assignment(policies, "deviceManagement/configurationPolicies/", "/assignments", token)
     policy_settings_batch = batch_request(
         policy_ids,
         "deviceManagement/configurationPolicies/",
@@ -73,7 +71,7 @@ def savebackup(path, output, exclude, token, prefix, append_id):
         # fname = clean_filename(name)
         fname = clean_filename(f"{name}_{str(policy['technologies']).split(',')[-1]}")
         if append_id:
-            fname = f"{fname}_{graph_id}"
+            fname = f"{fname}__{graph_id}"
         # Save Configuration Policy as JSON or YAML depending on configured
         # value in "-o"
         save_output(output, configpath, fname, policy)

--- a/src/IntuneCD/backup_customAttributeShellScript.py
+++ b/src/IntuneCD/backup_customAttributeShellScript.py
@@ -16,9 +16,7 @@ from .check_prefix import check_prefix_match
 
 # Set MS Graph endpoint
 ENDPOINT = "https://graph.microsoft.com/beta/deviceManagement/deviceCustomAttributeShellScripts/"
-ASSIGNMENT_ENDPOINT = (
-    "https://graph.microsoft.com/beta/deviceManagement/deviceManagementScripts"
-)
+ASSIGNMENT_ENDPOINT = "https://graph.microsoft.com/beta/deviceManagement/deviceManagementScripts"
 
 
 # Get all Custom Attribute Shell scripts and save them in specified path
@@ -45,9 +43,7 @@ def savebackup(path, output, exclude, token, prefix, append_id):
         "?$expand=assignments",
         token,
     )
-    script_data_responses = batch_request(
-        script_ids, "deviceManagement/deviceCustomAttributeShellScripts/", "", token
-    )
+    script_data_responses = batch_request(script_ids, "deviceManagement/deviceCustomAttributeShellScripts/", "", token)
 
     for script_data in script_data_responses:
         if prefix and not check_prefix_match(script_data["displayName"], prefix):
@@ -66,8 +62,11 @@ def savebackup(path, output, exclude, token, prefix, append_id):
 
         # Get filename without illegal characters
         fname = clean_filename(script_data["displayName"])
+        script_file_name = script_data["fileName"]
         if append_id:
-            fname = f"{fname}_{graph_id}"
+            fname = f"{fname}__{graph_id}"
+            script_name = script_data["fileName"].replace(".sh", "")
+            script_file_name = f"{script_name}__{graph_id}.sh"
 
         # Save Shell script as JSON or YAML depending on configured value in "-o"
         save_output(output, configpath, fname, script_data)
@@ -78,7 +77,7 @@ def savebackup(path, output, exclude, token, prefix, append_id):
         if not os.path.exists(configpath + "Script Data/"):
             os.makedirs(configpath + "Script Data/")
         decoded = base64.b64decode(script_data["scriptContent"]).decode("utf-8")
-        f = open(configpath + "Script Data/" + script_data["fileName"], "w")
+        f = open(configpath + "Script Data/" + script_file_name, "w")
         f.write(decoded)
 
     return results

--- a/src/IntuneCD/backup_deviceCategories.py
+++ b/src/IntuneCD/backup_deviceCategories.py
@@ -42,7 +42,7 @@ def savebackup(path, output, token, prefix, append_id):
             # Get filename without illegal characters
             fname = clean_filename(item["displayName"])
             if append_id:
-                fname = f"{fname}_{graph_id}"
+                fname = f"{fname}__{graph_id}"
             # Save Device Categories as JSON or YAML depending on configured value in "-o"
             save_output(output, configpath, fname, item)
 

--- a/src/IntuneCD/backup_enrollmentConfigurations.py
+++ b/src/IntuneCD/backup_enrollmentConfigurations.py
@@ -14,9 +14,7 @@ from .graph_batch import batch_assignment, get_object_assignment
 from .check_prefix import check_prefix_match
 
 # Set MS Graph endpoint
-ENDPOINT = (
-    "https://graph.microsoft.com/beta/deviceManagement/deviceEnrollmentConfigurations"
-)
+ENDPOINT = "https://graph.microsoft.com/beta/deviceManagement/deviceEnrollmentConfigurations"
 
 
 # Get all Enrollment Configurations and save them in specified path
@@ -33,18 +31,13 @@ def savebackup(path, output, exclude, token, prefix, append_id):
     configpath = path + "/" + "Enrollment Configurations/"
     data = makeapirequest(ENDPOINT, token)
 
-    assignment_responses = batch_assignment(
-        data, "deviceManagement/deviceEnrollmentConfigurations/", "/assignments", token
-    )
+    assignment_responses = batch_assignment(data, "deviceManagement/deviceEnrollmentConfigurations/", "/assignments", token)
 
     for config in data["value"]:
         if prefix and not check_prefix_match(config["displayName"], prefix):
             continue
 
-        if (
-            config["@odata.type"]
-            == "#microsoft.graph.windows10EnrollmentCompletionPageConfiguration"
-        ):
+        if config["@odata.type"] == "#microsoft.graph.windows10EnrollmentCompletionPageConfiguration":
             continue
         results["config_count"] += 1
         config_type = config.get("deviceEnrollmentConfigurationType", None)
@@ -60,11 +53,9 @@ def savebackup(path, output, exclude, token, prefix, append_id):
                 config["assignments"] = assignments
 
         graph_id = config["id"]
-        fname = clean_filename(
-            f"{config['displayName']}_{str(config['@odata.type']).split('.')[2]}"
-        )
+        fname = clean_filename(f"{config['displayName']}_{str(config['@odata.type']).split('.')[2]}")
         if append_id:
-            fname = f"{fname}_{graph_id}"
+            fname = f"{fname}__{graph_id}"
 
         config = remove_keys(config)
 

--- a/src/IntuneCD/backup_enrollmentStatusPage.py
+++ b/src/IntuneCD/backup_enrollmentStatusPage.py
@@ -12,9 +12,7 @@ from .remove_keys import remove_keys
 from .check_prefix import check_prefix_match
 
 # Set MS Graph endpoint
-ENDPOINT = (
-    "https://graph.microsoft.com/beta/deviceManagement/deviceEnrollmentConfigurations"
-)
+ENDPOINT = "https://graph.microsoft.com/beta/deviceManagement/deviceEnrollmentConfigurations"
 APP_ENDPOINT = "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps"
 
 
@@ -33,18 +31,13 @@ def savebackup(path, output, exclude, token, prefix, append_id):
     configpath = path + "/" + "Enrollment Profiles/Windows/ESP/"
     data = makeapirequest(ENDPOINT, token)
 
-    assignment_responses = batch_assignment(
-        data, "deviceManagement/deviceEnrollmentConfigurations/", "/assignments", token
-    )
+    assignment_responses = batch_assignment(data, "deviceManagement/deviceEnrollmentConfigurations/", "/assignments", token)
 
     for profile in data["value"]:
         if prefix and not check_prefix_match(profile["displayName"], prefix):
             continue
 
-        if (
-            profile["@odata.type"]
-            == "#microsoft.graph.windows10EnrollmentCompletionPageConfiguration"
-        ):
+        if profile["@odata.type"] == "#microsoft.graph.windows10EnrollmentCompletionPageConfiguration":
             results["config_count"] += 1
             if "assignments" not in exclude:
                 assignments = get_object_assignment(profile["id"], assignment_responses)
@@ -74,7 +67,7 @@ def savebackup(path, output, exclude, token, prefix, append_id):
             # Get filename without illegal characters
             fname = clean_filename(profile["displayName"])
             if append_id:
-                fname = f"{fname}_{graph_id}"
+                fname = f"{fname}__{graph_id}"
             # Save Windows Enrollment Profile as JSON or YAML depending on
             # configured value in "-o"
             save_output(output, configpath, fname, profile)

--- a/src/IntuneCD/backup_groupPolicyConfiguration.py
+++ b/src/IntuneCD/backup_groupPolicyConfiguration.py
@@ -30,18 +30,14 @@ def savebackup(path, output, exclude, token, prefix, append_id):
     configpath = path + "/" + "Group Policy Configurations/"
     data = makeapirequest(ENDPOINT, token)
 
-    assignment_responses = batch_assignment(
-        data, "deviceManagement/groupPolicyConfigurations/", "/assignments", token
-    )
+    assignment_responses = batch_assignment(data, "deviceManagement/groupPolicyConfigurations/", "/assignments", token)
 
     for profile in data["value"]:
         if prefix and not check_prefix_match(profile["displayName"], prefix):
             continue
 
         results["config_count"] += 1
-        definition_endpoint = (
-            f"{ENDPOINT}/{profile['id']}/definitionValues?$expand=definition"
-        )
+        definition_endpoint = f"{ENDPOINT}/{profile['id']}/definitionValues?$expand=definition"
         # Get definitions
         definitions = makeapirequest(definition_endpoint, token)
 
@@ -69,7 +65,7 @@ def savebackup(path, output, exclude, token, prefix, append_id):
         # Get filename without illegal characters
         fname = clean_filename(profile["displayName"])
         if append_id:
-            fname = f"{fname}_{graph_id}"
+            fname = f"{fname}__{graph_id}"
 
         save_output(output, configpath, fname, profile)
 

--- a/src/IntuneCD/backup_managedGPlay.py
+++ b/src/IntuneCD/backup_managedGPlay.py
@@ -36,7 +36,7 @@ def savebackup(path, output, token, append_id):
         # Get filename without illegal characters
         fname = clean_filename(data["ownerUserPrincipalName"])
         if append_id:
-            fname = f"{fname}_{graph_id}"
+            fname = f"{fname}__{graph_id}"
         # Save Managed Google Play as JSON or YAML depending on configured
         # value in "-o"
         save_output(output, configpath, fname, data)

--- a/src/IntuneCD/backup_managementIntents.py
+++ b/src/IntuneCD/backup_managementIntents.py
@@ -31,9 +31,7 @@ def savebackup(path, output, exclude, token, prefix, append_id):
     intents = makeapirequest(BASE_ENDPOINT + "/intents", token)
     templates = makeapirequest(TEMPLATE_ENDPOINT, token)
 
-    assignment_responses = batch_assignment(
-        intents, "deviceManagement/intents/", "/assignments", token
-    )
+    assignment_responses = batch_assignment(intents, "deviceManagement/intents/", "/assignments", token)
     intent_responses = batch_intents(intents, token)
 
     if intent_responses:
@@ -51,9 +49,7 @@ def savebackup(path, output, exclude, token, prefix, append_id):
             configpath = path + "/" + "Management Intents/" + template_type + "/"
 
             if "assignments" not in exclude:
-                assignments = get_object_assignment(
-                    intent_value["id"], assignment_responses
-                )
+                assignments = get_object_assignment(intent_value["id"], assignment_responses)
                 if assignments:
                     intent_value["assignments"] = assignments
 
@@ -65,7 +61,7 @@ def savebackup(path, output, exclude, token, prefix, append_id):
             # Get filename without illegal characters
             fname = clean_filename(intent_value["displayName"])
             if append_id:
-                fname = f"{fname}_{graph_id}"
+                fname = f"{fname}__{graph_id}"
             # Save Intent as JSON or YAML depending on configured value in "-o"
             save_output(output, configpath, fname, intent_value)
 

--- a/src/IntuneCD/backup_managementPartner.py
+++ b/src/IntuneCD/backup_managementPartner.py
@@ -40,7 +40,7 @@ def savebackup(path, output, token, append_id):
         # Get filename without illegal characters
         fname = clean_filename(partner["displayName"])
         if append_id:
-            fname = f"{fname}_{graph_id}"
+            fname = f"{fname}__{graph_id}"
         # Save Compliance policy as JSON or YAML depending on configured
         # value in "-o"
         save_output(output, configpath, fname, partner)

--- a/src/IntuneCD/backup_notificationTemplate.py
+++ b/src/IntuneCD/backup_notificationTemplate.py
@@ -11,9 +11,7 @@ from .remove_keys import remove_keys
 from .check_prefix import check_prefix_match
 
 # Set MS Graph endpoint
-ENDPOINT = (
-    "https://graph.microsoft.com/beta/deviceManagement/notificationMessageTemplates"
-)
+ENDPOINT = "https://graph.microsoft.com/beta/deviceManagement/notificationMessageTemplates"
 
 
 # Get all Notification Templates and save them in specified path
@@ -52,7 +50,7 @@ def savebackup(path, output, token, prefix, append_id):
         # Get filename without illegal characters
         fname = clean_filename(template_data["displayName"])
         if append_id:
-            fname = f"{fname}_{graph_id}"
+            fname = f"{fname}__{graph_id}"
         # Save Notification template as JSON or YAML depending on configured
         # value in "-o"
         save_output(output, configpath, fname, template_data)

--- a/src/IntuneCD/backup_powershellScripts.py
+++ b/src/IntuneCD/backup_powershellScripts.py
@@ -37,12 +37,8 @@ def savebackup(path, output, exclude, token, prefix, append_id):
         for script in data["value"]:
             script_ids.append(script["id"])
 
-        assignment_responses = batch_assignment(
-            data, "deviceManagement/deviceManagementScripts/", "/assignments", token
-        )
-        script_data_responses = batch_request(
-            script_ids, "deviceManagement/deviceManagementScripts/", "", token
-        )
+        assignment_responses = batch_assignment(data, "deviceManagement/deviceManagementScripts/", "/assignments", token)
+        script_data_responses = batch_request(script_ids, "deviceManagement/deviceManagementScripts/", "", token)
 
         for script_data in script_data_responses:
             if prefix and not check_prefix_match(script_data["displayName"], prefix):
@@ -50,9 +46,7 @@ def savebackup(path, output, exclude, token, prefix, append_id):
 
             results["config_count"] += 1
             if "assignments" not in exclude:
-                assignments = get_object_assignment(
-                    script_data["id"], assignment_responses
-                )
+                assignments = get_object_assignment(script_data["id"], assignment_responses)
                 if assignments:
                     script_data["assignments"] = assignments
 
@@ -63,8 +57,11 @@ def savebackup(path, output, exclude, token, prefix, append_id):
 
             # Get filename without illegal characters
             fname = clean_filename(script_data["displayName"])
+            script_file_name = script_data["fileName"]
             if append_id:
-                fname += "_" + graph_id
+                fname = f"{fname}__{graph_id}"
+                script_name = script_data["fileName"].replace(".ps1", "")
+                script_file_name = f"{script_name}__{graph_id}.ps1"
             # Save Powershell script as JSON or YAML depending on configured value
             # in "-o"
             save_output(output, configpath, fname, script_data)
@@ -76,7 +73,7 @@ def savebackup(path, output, exclude, token, prefix, append_id):
                 if not os.path.exists(configpath + "Script Data/"):
                     os.makedirs(configpath + "Script Data/")
                 decoded = base64.b64decode(script_data["scriptContent"]).decode("utf-8")
-                f = open(configpath + "Script Data/" + script_data["fileName"], "w")
+                f = open(configpath + "Script Data/" + script_file_name, "w")
                 f.write(decoded)
 
     return results

--- a/src/IntuneCD/backup_proactiveRemediation.py
+++ b/src/IntuneCD/backup_proactiveRemediation.py
@@ -37,12 +37,8 @@ def savebackup(path, output, exclude, token, prefix, append_id):
         for script in data["value"]:
             pr_ids.append(script["id"])
 
-        assignment_responses = batch_assignment(
-            data, "deviceManagement/deviceHealthScripts/", "/assignments", token
-        )
-        pr_data_responses = batch_request(
-            pr_ids, "deviceManagement/deviceHealthScripts/", "", token
-        )
+        assignment_responses = batch_assignment(data, "deviceManagement/deviceHealthScripts/", "/assignments", token)
+        pr_data_responses = batch_request(pr_ids, "deviceManagement/deviceHealthScripts/", "", token)
 
         for pr_details in pr_data_responses:
             if prefix and not check_prefix_match(pr_details["displayName"], prefix):
@@ -51,9 +47,7 @@ def savebackup(path, output, exclude, token, prefix, append_id):
             if "Microsoft" not in pr_details["publisher"]:
                 results["config_count"] += 1
                 if "assignments" not in exclude:
-                    assignments = get_object_assignment(
-                        pr_details["id"], assignment_responses
-                    )
+                    assignments = get_object_assignment(pr_details["id"], assignment_responses)
                     if assignments:
                         pr_details["assignments"] = assignments
 
@@ -65,7 +59,7 @@ def savebackup(path, output, exclude, token, prefix, append_id):
                 # Get filename without illegal characters
                 fname = clean_filename(pr_details["displayName"])
                 if append_id:
-                    fname = f"{fname}_{graph_id}"
+                    fname = f"{fname}__{graph_id}"
 
                 # Save Proactive Remediation as JSON or YAML depending on
                 # configured value in "-o"
@@ -80,19 +74,15 @@ def savebackup(path, output, exclude, token, prefix, append_id):
                 results["config_count"] += 1
                 fname = clean_filename(pr_details["displayName"])
                 if append_id:
-                    fname_id = f"_{graph_id}"
+                    fname_id = f"__{graph_id}"
                 else:
                     fname_id = ""
-                decoded = base64.b64decode(pr_details["detectionScriptContent"]).decode(
-                    "utf-8"
-                )
+                decoded = base64.b64decode(pr_details["detectionScriptContent"]).decode("utf-8")
                 f = open(f"{configpath}/Script Data/{fname}_DetectionScript{fname_id}.ps1", "w")
                 f.write(decoded)
                 # Save remediation script to the Script Data folder
                 results["config_count"] += 1
-                decoded = base64.b64decode(
-                    pr_details["remediationScriptContent"]
-                ).decode("utf-8")
+                decoded = base64.b64decode(pr_details["remediationScriptContent"]).decode("utf-8")
                 f = open(f"{configpath}/Script Data/{fname}_RemediationScript{fname_id}.ps1", "w")
                 f.write(decoded)
 

--- a/src/IntuneCD/backup_profiles.py
+++ b/src/IntuneCD/backup_profiles.py
@@ -33,9 +33,7 @@ def savebackup(path, output, exclude, token, prefix, append_id):
     configpath = path + "/" + "Device Configurations/"
     data = makeapirequest(ENDPOINT, token)
 
-    assignment_responses = batch_assignment(
-        data, "deviceManagement/deviceConfigurations/", "/assignments", token
-    )
+    assignment_responses = batch_assignment(data, "deviceManagement/deviceConfigurations/", "/assignments", token)
 
     for profile in data["value"]:
         if prefix and not check_prefix_match(profile["displayName"], prefix):
@@ -54,11 +52,9 @@ def savebackup(path, output, exclude, token, prefix, append_id):
         print("Backing up profile: " + profile["displayName"])
 
         # Get filename without illegal characters
-        fname = clean_filename(
-            f"{profile['displayName']}_{str(profile['@odata.type']).split('.')[2]}"
-        )
+        fname = clean_filename(f"{profile['displayName']}_{str(profile['@odata.type']).split('.')[2]}")
         if append_id:
-            fname = f"{fname}_{graph_id}"
+            fname = f"{fname}__{graph_id}"
 
         # If profile is custom macOS or iOS, decode the payload
         if (profile["@odata.type"] == "#microsoft.graph.macOSCustomConfiguration") or (
@@ -70,9 +66,7 @@ def savebackup(path, output, exclude, token, prefix, append_id):
                 os.makedirs(configpath + "/" + "mobileconfig/")
             # Save decoded payload as .mobileconfig
             results["config_count"] += 1
-            f = open(
-                configpath + "/" + "mobileconfig/" + profile["payloadFileName"], "w"
-            )
+            f = open(configpath + "/" + "mobileconfig/" + profile["payloadFileName"], "w")
             f.write(decoded)
             # Save Device Configuration as JSON or YAML depending on configured
             # value in "-o"

--- a/src/IntuneCD/backup_remoteAssistancePartner.py
+++ b/src/IntuneCD/backup_remoteAssistancePartner.py
@@ -40,7 +40,7 @@ def savebackup(path, output, token, append_id):
         # Get filename without illegal characters
         fname = clean_filename(partner["displayName"])
         if append_id:
-            fname = f"{fname}_{graph_id}"
+            fname = f"{fname}__{graph_id}"
         # Save Compliance policy as JSON or YAML depending on configured
         # value in "-o"
         save_output(output, configpath, fname, partner)

--- a/src/IntuneCD/backup_shellScripts.py
+++ b/src/IntuneCD/backup_shellScripts.py
@@ -16,9 +16,7 @@ from .check_prefix import check_prefix_match
 
 # Set MS Graph endpoint
 ENDPOINT = "https://graph.microsoft.com/beta/deviceManagement/deviceShellScripts/"
-ASSIGNMENT_ENDPOINT = (
-    "https://graph.microsoft.com/beta/deviceManagement/deviceManagementScripts"
-)
+ASSIGNMENT_ENDPOINT = "https://graph.microsoft.com/beta/deviceManagement/deviceManagementScripts"
 
 
 # Get all Shell scripts and save them in specified path
@@ -39,12 +37,8 @@ def savebackup(path, output, exclude, token, prefix, append_id):
     for script in data["value"]:
         script_ids.append(script["id"])
 
-    assignment_responses = batch_assignment(
-        data, "deviceManagement/deviceShellScripts/", "?$expand=assignments", token
-    )
-    script_data_responses = batch_request(
-        script_ids, "deviceManagement/deviceShellScripts/", "", token
-    )
+    assignment_responses = batch_assignment(data, "deviceManagement/deviceShellScripts/", "?$expand=assignments", token)
+    script_data_responses = batch_request(script_ids, "deviceManagement/deviceShellScripts/", "", token)
 
     for script_data in script_data_responses:
         if prefix and not check_prefix_match(script_data["displayName"], prefix):
@@ -63,8 +57,11 @@ def savebackup(path, output, exclude, token, prefix, append_id):
 
         # Get filename without illegal characters
         fname = clean_filename(script_data["displayName"])
+        script_file_name = script_data["fileName"]
         if append_id:
-            fname = f"{fname}_{graph_id}"
+            fname = f"{fname}__{graph_id}"
+            script_name = script_data["fileName"].replace(".sh", "")
+            script_file_name = f"{script_name}__{graph_id}.sh"
 
         # Save Shell script as JSON or YAML depending on configured value in "-o"
         save_output(output, configpath, fname, script_data)
@@ -75,7 +72,7 @@ def savebackup(path, output, exclude, token, prefix, append_id):
         if not os.path.exists(configpath + "Script Data/"):
             os.makedirs(configpath + "Script Data/")
         decoded = base64.b64decode(script_data["scriptContent"]).decode("utf-8")
-        f = open(configpath + "Script Data/" + script_data["fileName"], "w")
+        f = open(configpath + "Script Data/" + script_file_name, "w")
         f.write(decoded)
 
     return results

--- a/src/IntuneCD/backup_vppTokens.py
+++ b/src/IntuneCD/backup_vppTokens.py
@@ -38,7 +38,7 @@ def savebackup(path, output, token, append_id):
         # Get filename without illegal characters
         fname = clean_filename(token_name)
         if append_id:
-            fname = f"{fname}_{graph_id}"
+            fname = f"{fname}__{graph_id}"
 
         # Save token as JSON or YAML depending on configured value in "-o"
         save_output(output, configpath, fname, vpp_token)

--- a/src/IntuneCD/backup_windowsDriverUpdates.py
+++ b/src/IntuneCD/backup_windowsDriverUpdates.py
@@ -12,9 +12,7 @@ from .remove_keys import remove_keys
 from .check_prefix import check_prefix_match
 
 # Set MS Graph endpoint
-ENDPOINT = (
-    "https://graph.microsoft.com/beta/deviceManagement/windowsDriverUpdateProfiles"
-)
+ENDPOINT = "https://graph.microsoft.com/beta/deviceManagement/windowsDriverUpdateProfiles"
 
 
 # Get all Windows Driver Profiles and save them in specified path
@@ -57,7 +55,7 @@ def savebackup(path, output, exclude, token, prefix, append_id):
         # Get filename without illegal characters
         fname = clean_filename(profile["displayName"])
         if append_id:
-            fname = f"{fname}_{graph_id}"
+            fname = f"{fname}__{graph_id}"
         # Save Windows Enrollment Profile as JSON or YAML depending on
         # configured value in "-o"
         save_output(output, configpath, fname, profile)

--- a/src/IntuneCD/backup_windowsEnrollmentProfile.py
+++ b/src/IntuneCD/backup_windowsEnrollmentProfile.py
@@ -55,7 +55,7 @@ def savebackup(path, output, exclude, token, prefix, append_id):
         # Get filename without illegal characters
         fname = clean_filename(profile["displayName"])
         if append_id:
-            fname = f"{fname}_{graph_id}"
+            fname = f"{fname}__{graph_id}"
         # Save Windows Enrollment Profile as JSON or YAML depending on
         # configured value in "-o"
         save_output(output, configpath, fname, profile)

--- a/src/IntuneCD/backup_windowsFeatureUpdates.py
+++ b/src/IntuneCD/backup_windowsFeatureUpdates.py
@@ -12,9 +12,7 @@ from .remove_keys import remove_keys
 from .check_prefix import check_prefix_match
 
 # Set MS Graph endpoint
-ENDPOINT = (
-    "https://graph.microsoft.com/beta/deviceManagement/windowsFeatureUpdateProfiles"
-)
+ENDPOINT = "https://graph.microsoft.com/beta/deviceManagement/windowsFeatureUpdateProfiles"
 
 
 # Get all Windows Feature Profiles and save them in specified path
@@ -57,7 +55,7 @@ def savebackup(path, output, exclude, token, prefix, append_id):
         # Get filename without illegal characters
         fname = clean_filename(profile["displayName"])
         if append_id:
-            fname = f"{fname}_{graph_id}"
+            fname = f"{fname}__{graph_id}"
         # Save Windows Enrollment Profile as JSON or YAML depending on
         # configured value in "-o"
         save_output(output, configpath, fname, profile)

--- a/src/IntuneCD/backup_windowsQualityUpdates.py
+++ b/src/IntuneCD/backup_windowsQualityUpdates.py
@@ -12,9 +12,7 @@ from .remove_keys import remove_keys
 from .check_prefix import check_prefix_match
 
 # Set MS Graph endpoint
-ENDPOINT = (
-    "https://graph.microsoft.com/beta/deviceManagement/windowsQualityUpdateProfiles"
-)
+ENDPOINT = "https://graph.microsoft.com/beta/deviceManagement/windowsQualityUpdateProfiles"
 
 
 # Get all Windows Quality Profiles and save them in specified path
@@ -57,7 +55,7 @@ def savebackup(path, output, exclude, token, prefix, append_id):
         # Get filename without illegal characters
         fname = clean_filename(profile["displayName"])
         if append_id:
-            fname = f"{fname}_{graph_id}"
+            fname = f"{fname}__{graph_id}"
         # Save Windows Enrollment Profile as JSON or YAML depending on
         # configured value in "-o"
         save_output(output, configpath, fname, profile)

--- a/src/IntuneCD/graph_request.py
+++ b/src/IntuneCD/graph_request.py
@@ -39,8 +39,8 @@ def makeapirequest(endpoint, token, q_param=None):
         response = requests.get(endpoint, headers=headers)
         if response.status_code == 504 or response.status_code == 502 or response.status_code == 503:
             retry_count = 0
-            print("Ran into issues with Graph request, waiting 10 seconds and trying again...")
             while retry_count < 3:
+                print("Ran into issues with Graph request, waiting 10 seconds and trying again...")
                 time.sleep(10)
                 response = requests.get(endpoint, headers=headers)
                 if response.status_code == 200:

--- a/src/IntuneCD/graph_request.py
+++ b/src/IntuneCD/graph_request.py
@@ -38,9 +38,14 @@ def makeapirequest(endpoint, token, q_param=None):
     else:
         response = requests.get(endpoint, headers=headers)
         if response.status_code == 504 or response.status_code == 502 or response.status_code == 503:
+            retry_count = 0
             print("Ran into issues with Graph request, waiting 10 seconds and trying again...")
-            time.sleep(10)
-            response = requests.get(endpoint, headers=headers)
+            while retry_count < 3:
+                time.sleep(10)
+                response = requests.get(endpoint, headers=headers)
+                if response.status_code == 200:
+                    break
+                retry_count += 1
         elif response.status_code == 429:
             print(f"Hit Graph throttling, trying again after {response.headers['Retry-After']} seconds")
             while response.status_code == 429:

--- a/src/IntuneCD/update_customAttributeShellScript.py
+++ b/src/IntuneCD/update_customAttributeShellScript.py
@@ -24,14 +24,10 @@ from .diff_summary import DiffSummary
 
 # Set MS Graph endpoint
 ENDPOINT = "https://graph.microsoft.com/beta/deviceManagement/deviceCustomAttributeShellScripts"
-ASSIGNMENT_ENDPOINT = (
-    "https://graph.microsoft.com/beta/deviceManagement/deviceManagementScripts"
-)
+ASSIGNMENT_ENDPOINT = "https://graph.microsoft.com/beta/deviceManagement/deviceManagementScripts"
 
 
-def update(
-    path, token, assignment=False, report=False, create_groups=False, remove=False
-):
+def update(path, token, assignment=False, report=False, create_groups=False, remove=False):
     """
     This function updates all Custom Attribute Shell scripts in Intune if the configuration in Intune differs from the JSON/YAML file.
 
@@ -82,9 +78,7 @@ def update(
                     print("-" * 90)
                     q_param = None
                     # Get Shell script details
-                    mem_data = makeapirequest(
-                        ENDPOINT + "/" + data["value"]["id"], token
-                    )
+                    mem_data = makeapirequest(ENDPOINT + "/" + data["value"]["id"], token)
                     mem_id = mem_data["id"]
                     # Remove keys before using DeepDiff
                     mem_data = remove_keys(mem_data)
@@ -99,21 +93,20 @@ def update(
                         mem_data.pop(key, None)
 
                     # Check if script data is saved and read the file
-                    if os.path.exists(
-                        configpath + "/Script Data/" + repo_data["fileName"]
-                    ):
-                        with open(
-                            configpath + "/Script Data/" + repo_data["fileName"], "r"
-                        ) as f:
+                    fname_id = filename.split("__")
+                    if len(fname_id) > 1:
+                        fname_id = fname_id[1].replace(".json", "").replace(".yaml", "")
+                    else:
+                        fname_id = ""
+                    script_files = os.listdir(configpath + "/Script Data/")
+                    script_file = [x for x in script_files if fname_id in x or repo_data["fileName"] in x]
+                    if script_file:
+                        with open(configpath + "/Script Data/" + script_file[0], "r") as f:
                             repo_payload_config = f.read()
 
-                        mem_payload_config = base64.b64decode(
-                            mem_data["scriptContent"]
-                        ).decode("utf-8")
+                        mem_payload_config = base64.b64decode(mem_data["scriptContent"]).decode("utf-8")
 
-                        pdiff = DeepDiff(
-                            mem_payload_config, repo_payload_config, ignore_order=True
-                        ).get("values_changed", {})
+                        pdiff = DeepDiff(mem_payload_config, repo_payload_config, ignore_order=True).get("values_changed", {})
                         cdiff = DeepDiff(
                             mem_data,
                             repo_data,
@@ -124,14 +117,10 @@ def update(
                         # If any changed values are found, push them to Intune
                         if pdiff or cdiff and report is False:
                             shell_bytes = repo_payload_config.encode("utf-8")
-                            repo_data["scriptContent"] = base64.b64encode(
-                                shell_bytes
-                            ).decode("utf-8")
+                            repo_data["scriptContent"] = base64.b64encode(shell_bytes).decode("utf-8")
                             request_data = json.dumps(repo_data)
                             q_param = None
-                            makeapirequestPatch(
-                                ENDPOINT + "/" + mem_id, token, q_param, request_data
-                            )
+                            makeapirequestPatch(ENDPOINT + "/" + mem_id, token, q_param, request_data)
 
                         diff_config = DiffSummary(
                             data=cdiff,
@@ -154,9 +143,7 @@ def update(
 
                     if assignment:
                         mem_assign_obj = get_object_assignment(mem_id, mem_assignments)
-                        update = update_assignment(
-                            assign_obj, mem_assign_obj, token, create_groups
-                        )
+                        update = update_assignment(assign_obj, mem_assign_obj, token, create_groups)
                         if update is not None:
                             request_data = {"deviceManagementScriptAssignments": update}
                             post_assignment_update(
@@ -170,10 +157,7 @@ def update(
                 # If Custom Attribute Shell script does not exist, create it and assign
                 else:
                     print("-" * 90)
-                    print(
-                        "Custom Attribute not found, creating script: "
-                        + repo_data["displayName"]
-                    )
+                    print("Custom Attribute not found, creating script: " + repo_data["displayName"])
                     if report is False:
                         request_json = json.dumps(repo_data)
                         post_request = makeapirequestPost(
@@ -184,13 +168,9 @@ def update(
                             status_code=201,
                         )
                         mem_assign_obj = []
-                        assignment = update_assignment(
-                            assign_obj, mem_assign_obj, token, create_groups
-                        )
+                        assignment = update_assignment(assign_obj, mem_assign_obj, token, create_groups)
                         if assignment is not None:
-                            request_data = {
-                                "deviceManagementScriptAssignments": assignment
-                            }
+                            request_data = {"deviceManagementScriptAssignments": assignment}
                             post_assignment_update(
                                 request_data,
                                 post_request["id"],
@@ -206,8 +186,6 @@ def update(
                 print("-" * 90)
                 print("Removing Custom Attribute from Intune: " + val["displayName"])
                 if report is False:
-                    makeapirequestDelete(
-                        f"{ENDPOINT}/{val['id']}", token, status_code=200
-                    )
+                    makeapirequestDelete(f"{ENDPOINT}/{val['id']}", token, status_code=200)
 
     return diff_summary

--- a/src/IntuneCD/update_shellScripts.py
+++ b/src/IntuneCD/update_shellScripts.py
@@ -24,14 +24,10 @@ from .diff_summary import DiffSummary
 
 # Set MS Graph endpoint
 ENDPOINT = "https://graph.microsoft.com/beta/deviceManagement/deviceShellScripts"
-ASSIGNMENT_ENDPOINT = (
-    "https://graph.microsoft.com/beta/deviceManagement/deviceManagementScripts"
-)
+ASSIGNMENT_ENDPOINT = "https://graph.microsoft.com/beta/deviceManagement/deviceManagementScripts"
 
 
-def update(
-    path, token, assignment=False, report=False, create_groups=False, remove=False
-):
+def update(path, token, assignment=False, report=False, create_groups=False, remove=False):
     """
     This function updates all Shell scripts in Intune if the configuration in Intune differs from the JSON/YAML file.
 
@@ -82,29 +78,26 @@ def update(
                     print("-" * 90)
                     q_param = None
                     # Get Shell script details
-                    mem_data = makeapirequest(
-                        ENDPOINT + "/" + data["value"]["id"], token
-                    )
+                    mem_data = makeapirequest(ENDPOINT + "/" + data["value"]["id"], token)
                     mem_id = mem_data["id"]
                     # Remove keys before using DeepDiff
                     mem_data = remove_keys(mem_data)
 
                     # Check if script data is saved and read the file
-                    if os.path.exists(
-                        configpath + "/Script Data/" + repo_data["fileName"]
-                    ):
-                        with open(
-                            configpath + "/Script Data/" + repo_data["fileName"], "r"
-                        ) as f:
+                    fname_id = filename.split("__")
+                    if len(fname_id) > 1:
+                        fname_id = fname_id[1].replace(".json", "").replace(".yaml", "")
+                    else:
+                        fname_id = ""
+                    script_files = os.listdir(configpath + "/Script Data/")
+                    script_file = [x for x in script_files if fname_id in x or repo_data["fileName"] in x]
+                    if script_file:
+                        with open(configpath + "/Script Data/" + script_file[0], "r") as f:
                             repo_payload_config = f.read()
 
-                        mem_payload_config = base64.b64decode(
-                            mem_data["scriptContent"]
-                        ).decode("utf-8")
+                        mem_payload_config = base64.b64decode(mem_data["scriptContent"]).decode("utf-8")
 
-                        pdiff = DeepDiff(
-                            mem_payload_config, repo_payload_config, ignore_order=True
-                        ).get("values_changed", {})
+                        pdiff = DeepDiff(mem_payload_config, repo_payload_config, ignore_order=True).get("values_changed", {})
                         cdiff = DeepDiff(
                             mem_data,
                             repo_data,
@@ -115,14 +108,10 @@ def update(
                         # If any changed values are found, push them to Intune
                         if pdiff or cdiff and report is False:
                             shell_bytes = repo_payload_config.encode("utf-8")
-                            repo_data["scriptContent"] = base64.b64encode(
-                                shell_bytes
-                            ).decode("utf-8")
+                            repo_data["scriptContent"] = base64.b64encode(shell_bytes).decode("utf-8")
                             request_data = json.dumps(repo_data)
                             q_param = None
-                            makeapirequestPatch(
-                                ENDPOINT + "/" + mem_id, token, q_param, request_data
-                            )
+                            makeapirequestPatch(ENDPOINT + "/" + mem_id, token, q_param, request_data)
 
                         diff_config = DiffSummary(
                             data=cdiff,
@@ -145,9 +134,7 @@ def update(
 
                     if assignment:
                         mem_assign_obj = get_object_assignment(mem_id, mem_assignments)
-                        update = update_assignment(
-                            assign_obj, mem_assign_obj, token, create_groups
-                        )
+                        update = update_assignment(assign_obj, mem_assign_obj, token, create_groups)
                         if update is not None:
                             request_data = {"deviceManagementScriptAssignments": update}
                             post_assignment_update(
@@ -161,10 +148,7 @@ def update(
                 # If Shell script does not exist, create it and assign
                 else:
                     print("-" * 90)
-                    print(
-                        "Shell script not found, creating script: "
-                        + repo_data["displayName"]
-                    )
+                    print("Shell script not found, creating script: " + repo_data["displayName"])
                     if report is False:
                         request_json = json.dumps(repo_data)
                         post_request = makeapirequestPost(
@@ -175,13 +159,9 @@ def update(
                             status_code=201,
                         )
                         mem_assign_obj = []
-                        assignment = update_assignment(
-                            assign_obj, mem_assign_obj, token, create_groups
-                        )
+                        assignment = update_assignment(assign_obj, mem_assign_obj, token, create_groups)
                         if assignment is not None:
-                            request_data = {
-                                "deviceManagementScriptAssignments": assignment
-                            }
+                            request_data = {"deviceManagementScriptAssignments": assignment}
                             post_assignment_update(
                                 request_data,
                                 post_request["id"],
@@ -197,8 +177,6 @@ def update(
                 print("-" * 90)
                 print("Removing Shell Script from Intune: " + val["displayName"])
                 if report is False:
-                    makeapirequestDelete(
-                        f"{ENDPOINT}/{val['id']}", token, status_code=200
-                    )
+                    makeapirequestDelete(f"{ENDPOINT}/{val['id']}", token, status_code=200)
 
     return diff_summary

--- a/tests/Backup/test_backup_appConfiguration.py
+++ b/tests/Backup/test_backup_appConfiguration.py
@@ -24,9 +24,7 @@ class TestBackupAppConfig(unittest.TestCase):
         self.token = "token"
         self.exclude = []
         self.append_id = False
-        self.saved_path = (
-            f"{self.directory.path}/App Configuration/test_iosMobileAppConfiguration."
-        )
+        self.saved_path = f"{self.directory.path}/App Configuration/test_iosMobileAppConfiguration."
         self.expected_data = {
             "@odata.type": "#microsoft.graph.iosMobileAppConfiguration",
             "assignments": [{"target": {"groupName": "Group1"}}],
@@ -73,21 +71,15 @@ class TestBackupAppConfig(unittest.TestCase):
             "revokeLicenseActionResults": [],
         }
 
-        self.batch_assignment_patch = patch(
-            "src.IntuneCD.backup_appConfiguration.batch_assignment"
-        )
+        self.batch_assignment_patch = patch("src.IntuneCD.backup_appConfiguration.batch_assignment")
         self.batch_assignment = self.batch_assignment_patch.start()
         self.batch_assignment.return_value = BATCH_ASSIGNMENT
 
-        self.object_assignment_patch = patch(
-            "src.IntuneCD.backup_appConfiguration.get_object_assignment"
-        )
+        self.object_assignment_patch = patch("src.IntuneCD.backup_appConfiguration.get_object_assignment")
         self.object_assignment = self.object_assignment_patch.start()
         self.object_assignment.return_value = OBJECT_ASSIGNMENT
 
-        self.makeapirequest_patch = patch(
-            "src.IntuneCD.backup_appConfiguration.makeapirequest"
-        )
+        self.makeapirequest_patch = patch("src.IntuneCD.backup_appConfiguration.makeapirequest")
         self.makeapirequest = self.makeapirequest_patch.start()
         self.makeapirequest.side_effect = self.app_config, self.app_data
 
@@ -100,9 +92,7 @@ class TestBackupAppConfig(unittest.TestCase):
     def test_backup_yml(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "yaml", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "yaml", self.exclude, self.token, "", self.append_id)
 
         with open(self.saved_path + "yaml", "r") as f:
             data = json.dumps(yaml.safe_load(f))
@@ -115,9 +105,7 @@ class TestBackupAppConfig(unittest.TestCase):
     def test_backup_json(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", self.append_id)
 
         with open(self.saved_path + "json", "r") as f:
             saved_data = json.load(f)
@@ -129,9 +117,7 @@ class TestBackupAppConfig(unittest.TestCase):
     def test_backup_with_no_returned_data(self):
         """The count should be 0 if no data is returned."""
         self.makeapirequest.side_effect = [{"value": []}]
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", self.append_id)
 
         self.assertEqual(0, self.count["config_count"])
 
@@ -151,15 +137,9 @@ class TestBackupAppConfig(unittest.TestCase):
     def test_backup_append_id(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "yaml", self.exclude, self.token, "", True
-        )
+        self.count = savebackup(self.directory.path, "yaml", self.exclude, self.token, "", True)
 
-        self.assertTrue(
-            Path(
-                f"{self.directory.path}/App Configuration/test_iosMobileAppConfiguration_0.yaml"
-            ).exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/App Configuration/test_iosMobileAppConfiguration__0.yaml").exists())
 
 
 if __name__ == "__main__":

--- a/tests/Backup/test_backup_appProtection.py
+++ b/tests/Backup/test_backup_appProtection.py
@@ -24,12 +24,8 @@ class TestBackupAppProtection(unittest.TestCase):
         self.token = "token"
         self.exclude = []
         self.append_id = False
-        self.saved_path = (
-            f"{self.directory.path}/App Protection/test_iosManagedAppProtection."
-        )
-        self.saved_targetedAppManagementLevels = (
-            f"{self.directory.path}/App Protection/test_test."
-        )
+        self.saved_path = f"{self.directory.path}/App Protection/test_iosManagedAppProtection."
+        self.saved_targetedAppManagementLevels = f"{self.directory.path}/App Protection/test_test."
         self.expected_data = {
             "@odata.type": "#microsoft.graph.iosManagedAppProtection",
             "displayName": "test",
@@ -63,21 +59,15 @@ class TestBackupAppProtection(unittest.TestCase):
             ],
         }
 
-        self.batch_assignment_patch = patch(
-            "src.IntuneCD.backup_AppProtection.batch_assignment"
-        )
+        self.batch_assignment_patch = patch("src.IntuneCD.backup_AppProtection.batch_assignment")
         self.batch_assignment = self.batch_assignment_patch.start()
         self.batch_assignment.return_value = BATCH_ASSIGNMENT
 
-        self.object_assignment_patch = patch(
-            "src.IntuneCD.backup_AppProtection.get_object_assignment"
-        )
+        self.object_assignment_patch = patch("src.IntuneCD.backup_AppProtection.get_object_assignment")
         self.object_assignment = self.object_assignment_patch.start()
         self.object_assignment.return_value = OBJECT_ASSIGNMENT
 
-        self.makeapirequest_patch = patch(
-            "src.IntuneCD.backup_AppProtection.makeapirequest"
-        )
+        self.makeapirequest_patch = patch("src.IntuneCD.backup_AppProtection.makeapirequest")
         self.makeapirequest = self.makeapirequest_patch.start()
         self.makeapirequest.return_value = self.app_protection
 
@@ -90,9 +80,7 @@ class TestBackupAppProtection(unittest.TestCase):
     def test_backup_yml(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "yaml", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "yaml", self.exclude, self.token, "", self.append_id)
 
         with open(self.saved_path + "yaml", "r") as f:
             data = json.dumps(yaml.safe_load(f))
@@ -105,9 +93,7 @@ class TestBackupAppProtection(unittest.TestCase):
     def test_backup_json(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", self.append_id)
 
         with open(self.saved_path + "json", "r") as f:
             self.saved_data = json.load(f)
@@ -119,14 +105,8 @@ class TestBackupAppProtection(unittest.TestCase):
     def test_backup_targetedManagedAppConfiguration(self):
         """The count should be 0 since the targetedManagedAppConfiguration is not supported."""
 
-        self.makeapirequest.return_value = {
-            "value": [
-                {"@odata.type": "#microsoft.graph.targetedManagedAppConfiguration"}
-            ]
-        }
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", self.append_id
-        )
+        self.makeapirequest.return_value = {"value": [{"@odata.type": "#microsoft.graph.targetedManagedAppConfiguration"}]}
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", self.append_id)
         self.assertEqual(0, self.count["config_count"])
 
     def test_backup_targetedAppManagementLevels(self):
@@ -135,9 +115,7 @@ class TestBackupAppProtection(unittest.TestCase):
         self.app_protection["value"][0]["targetedAppManagementLevels"] = "test"
         self.expected_data["targetedAppManagementLevels"] = "test"
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", self.append_id)
 
         with open(self.saved_targetedAppManagementLevels + "json", "r") as f:
             self.saved_data = json.load(f)
@@ -150,9 +128,7 @@ class TestBackupAppProtection(unittest.TestCase):
         """The count should be 0 if no data is returned."""
 
         self.makeapirequest.return_value = {"value": []}
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", self.append_id)
         self.assertEqual(0, self.count["config_count"])
 
     def test_backup_with_prefix(self):
@@ -171,15 +147,9 @@ class TestBackupAppProtection(unittest.TestCase):
     def test_backup_append_id(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", True
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", True)
 
-        self.assertTrue(
-            Path(
-                f"{self.directory.path}/App Protection/test_iosManagedAppProtection_T_0.json"
-            ).exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/App Protection/test_iosManagedAppProtection__T_0.json").exists())
 
 
 if __name__ == "__main__":

--- a/tests/Backup/test_backup_appleEnrollmentProfile.py
+++ b/tests/Backup/test_backup_appleEnrollmentProfile.py
@@ -62,14 +62,10 @@ class TestBackupAppleEnrollmentProfile(unittest.TestCase):
             }
         ]
 
-        self.patch_makeapirequest = patch(
-            "src.IntuneCD.backup_appleEnrollmentProfile.makeapirequest"
-        )
+        self.patch_makeapirequest = patch("src.IntuneCD.backup_appleEnrollmentProfile.makeapirequest")
         self.makeapirequest = self.patch_makeapirequest.start()
 
-        self.patch_batch_request = patch(
-            "src.IntuneCD.backup_appleEnrollmentProfile.batch_request"
-        )
+        self.patch_batch_request = patch("src.IntuneCD.backup_appleEnrollmentProfile.batch_request")
         self.batch_request = self.patch_batch_request.start()
 
     def tearDown(self):
@@ -81,17 +77,13 @@ class TestBackupAppleEnrollmentProfile(unittest.TestCase):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
         self.makeapirequest.return_value = self.token_response
         self.batch_request.return_value = self.batch_intune
-        self.count = savebackup(
-            self.directory.path, "yaml", self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "yaml", self.token, "", self.append_id)
 
         with open(self.saved_path + "yaml", "r") as f:
             data = json.dumps(yaml.safe_load(f))
             self.saved_data = json.loads(data)
 
-        self.assertTrue(
-            Path(f"{self.directory.path}/Enrollment Profiles/Apple").exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Enrollment Profiles/Apple").exists())
         self.assertEqual(self.expected_data, self.saved_data)
         self.assertEqual(1, self.count["config_count"])
 
@@ -99,17 +91,13 @@ class TestBackupAppleEnrollmentProfile(unittest.TestCase):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
         self.makeapirequest.return_value = self.token_response
         self.batch_request.return_value = self.batch_intune
-        self.count = savebackup(
-            self.directory.path, "json", self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.token, "", self.append_id)
 
         with open(self.saved_path + "json", "r") as f:
             data = json.dumps(yaml.safe_load(f))
             self.saved_data = json.loads(data)
 
-        self.assertTrue(
-            Path(f"{self.directory.path}/Enrollment Profiles/Apple").exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Enrollment Profiles/Apple").exists())
         self.assertEqual(self.expected_data, self.saved_data)
         self.assertEqual(1, self.count["config_count"])
 
@@ -117,9 +105,7 @@ class TestBackupAppleEnrollmentProfile(unittest.TestCase):
         """The count should be 0 if no data is returned."""
 
         self.makeapirequest.return_value = {"value": []}
-        self.count = savebackup(
-            self.directory.path, "json", self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.token, "", self.append_id)
 
         self.assertEqual(0, self.count["config_count"])
 
@@ -127,9 +113,7 @@ class TestBackupAppleEnrollmentProfile(unittest.TestCase):
         """The count should be 0 if no data is returned."""
 
         self.makeapirequest.return_value = {"value": []}
-        self.count = savebackup(
-            self.directory.path, "json", self.token, "test", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.token, "test", self.append_id)
 
         self.assertEqual(0, self.count["config_count"])
 
@@ -140,11 +124,7 @@ class TestBackupAppleEnrollmentProfile(unittest.TestCase):
 
         self.count = savebackup(self.directory.path, "json", self.token, "", True)
 
-        self.assertTrue(
-            Path(
-                f"{self.directory.path}/Enrollment Profiles/Apple/test_0.json"
-            ).exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Enrollment Profiles/Apple/test__0.json").exists())
 
 
 if __name__ == "__main__":

--- a/tests/Backup/test_backup_applications.py
+++ b/tests/Backup/test_backup_applications.py
@@ -44,21 +44,15 @@ class TestBackupApplications(unittest.TestCase):
         ]
         self.object_assignment_data = [{"target": {"groupName": "Group1"}}]
 
-        self.batch_assignment_patch = patch(
-            "src.IntuneCD.backup_applications.batch_assignment"
-        )
+        self.batch_assignment_patch = patch("src.IntuneCD.backup_applications.batch_assignment")
         self.batch_assignment = self.batch_assignment_patch.start()
         self.batch_assignment.return_value = self.batch_assignment_data
 
-        self.object_assignment_patch = patch(
-            "src.IntuneCD.backup_applications.get_object_assignment"
-        )
+        self.object_assignment_patch = patch("src.IntuneCD.backup_applications.get_object_assignment")
         self.object_assignment = self.object_assignment_patch.start()
         self.object_assignment.return_value = self.object_assignment_data
 
-        self.makeapirequest_patch = patch(
-            "src.IntuneCD.backup_applications.makeapirequest"
-        )
+        self.makeapirequest_patch = patch("src.IntuneCD.backup_applications.makeapirequest")
         self.makeapirequest = self.makeapirequest_patch.start()
 
     def tearDown(self):
@@ -73,16 +67,10 @@ class TestBackupApplications(unittest.TestCase):
         self.app_base_data["value"][0]["@odata.type"] = "#microsoft.graph.iosVppApp"
         self.makeapirequest.return_value = self.app_base_data
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, self.append_id)
 
         self.assertTrue(Path(self.directory.path + "/Applications/iOS").exists())
-        self.assertTrue(
-            Path(
-                self.directory.path + "/Applications/iOS/test_iOSVppApp_test.json"
-            ).exists()
-        )
+        self.assertTrue(Path(self.directory.path + "/Applications/iOS/test_iOSVppApp_test.json").exists())
         self.assertEqual(1, self.count["config_count"])
 
     def test_backup_macOS_vpp_app(self):
@@ -91,16 +79,10 @@ class TestBackupApplications(unittest.TestCase):
         self.app_base_data["value"][0]["@odata.type"] = "#microsoft.graph.macOsVppApp"
         self.makeapirequest.return_value = self.app_base_data
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, self.append_id)
 
         self.assertTrue(Path(self.directory.path + "/Applications/macOS").exists())
-        self.assertTrue(
-            Path(
-                self.directory.path + "/Applications/macOS/test_macOSVppApp_test.json"
-            ).exists()
-        )
+        self.assertTrue(Path(self.directory.path + "/Applications/macOS/test_macOSVppApp_test.json").exists())
         self.assertEqual(1, self.count["config_count"])
 
     def test_backup_win32_lob_app_and_displayVersion(self):
@@ -110,16 +92,10 @@ class TestBackupApplications(unittest.TestCase):
         self.app_base_data["value"][0]["displayVersion"] = "1.0.0"
         self.makeapirequest.return_value = self.app_base_data
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, self.append_id)
 
         self.assertTrue(Path(self.directory.path + "/Applications/Windows").exists())
-        self.assertTrue(
-            Path(
-                self.directory.path + "/Applications/Windows/test_Win32_1_0_0.json"
-            ).exists()
-        )
+        self.assertTrue(Path(self.directory.path + "/Applications/Windows/test_Win32_1_0_0.json").exists())
         self.assertEqual(1, self.count["config_count"])
 
     def test_backup_win32_lob_app_no_displayVersion(self):
@@ -129,56 +105,35 @@ class TestBackupApplications(unittest.TestCase):
         self.app_base_data["value"][0]["displayVersion"] = None
         self.makeapirequest.return_value = self.app_base_data
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, self.append_id)
 
         self.assertTrue(Path(self.directory.path + "/Applications/Windows").exists())
-        self.assertTrue(
-            Path(self.directory.path + "/Applications/Windows/test_Win32.json").exists()
-        )
+        self.assertTrue(Path(self.directory.path + "/Applications/Windows/test_Win32.json").exists())
         self.assertEqual(1, self.count["config_count"])
 
     def test_backup_msi_app(self):
         """The folder should be created, the file should be created, and the count should be 1."""
 
-        self.app_base_data["value"][0][
-            "@odata.type"
-        ] = "#microsoft.graph.windowsMobileMSI"
+        self.app_base_data["value"][0]["@odata.type"] = "#microsoft.graph.windowsMobileMSI"
         self.app_base_data["value"][0]["productVersion"] = "1.0.0"
         self.makeapirequest.return_value = self.app_base_data
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, self.append_id)
 
         self.assertTrue(Path(self.directory.path + "/Applications/Windows").exists())
-        self.assertTrue(
-            Path(
-                self.directory.path + "/Applications/Windows/test_WinMSI_1_0_0.json"
-            ).exists()
-        )
+        self.assertTrue(Path(self.directory.path + "/Applications/Windows/test_WinMSI_1_0_0.json").exists())
         self.assertEqual(1, self.count["config_count"])
 
     def test_backup_android_app(self):
         """The folder should be created, the file should be created, and the count should be 1."""
 
-        self.app_base_data["value"][0][
-            "@odata.type"
-        ] = "#microsoft.graph.androidManagedStoreApp"
+        self.app_base_data["value"][0]["@odata.type"] = "#microsoft.graph.androidManagedStoreApp"
         self.makeapirequest.return_value = self.app_base_data
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, self.append_id)
 
         self.assertTrue(Path(self.directory.path + "/Applications/Android").exists())
-        self.assertTrue(
-            Path(
-                self.directory.path
-                + "/Applications/Android/test_androidManagedStoreApp.json"
-            ).exists()
-        )
+        self.assertTrue(Path(self.directory.path + "/Applications/Android/test_androidManagedStoreApp.json").exists())
         self.assertEqual(1, self.count["config_count"])
 
     def test_backup_microsoft_app(self):
@@ -187,39 +142,22 @@ class TestBackupApplications(unittest.TestCase):
         self.app_base_data["value"][0]["@odata.type"] = "#microsoft.graph.microsoftApp"
         self.makeapirequest.return_value = self.app_base_data
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, self.append_id)
 
         self.assertTrue(Path(self.directory.path + "/Applications/Windows").exists())
-        self.assertTrue(
-            Path(
-                self.directory.path + "/Applications/Windows/test_microsoftApp.json"
-            ).exists()
-        )
+        self.assertTrue(Path(self.directory.path + "/Applications/Windows/test_microsoftApp.json").exists())
         self.assertEqual(1, self.count["config_count"])
 
     def test_backup_office_suite_app(self):
         """The folder should be created, the file should be created, and the count should be 1."""
 
-        self.app_base_data["value"][0][
-            "@odata.type"
-        ] = "#microsoft.graph.microsoftOfficeSuiteApp"
+        self.app_base_data["value"][0]["@odata.type"] = "#microsoft.graph.microsoftOfficeSuiteApp"
         self.makeapirequest.return_value = self.app_base_data
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, self.append_id)
 
-        self.assertTrue(
-            Path(self.directory.path + "/Applications/Office Suite").exists()
-        )
-        self.assertTrue(
-            Path(
-                self.directory.path
-                + "/Applications/Office Suite/test_microsoftOfficeSuiteApp.json"
-            ).exists()
-        )
+        self.assertTrue(Path(self.directory.path + "/Applications/Office Suite").exists())
+        self.assertTrue(Path(self.directory.path + "/Applications/Office Suite/test_microsoftOfficeSuiteApp.json").exists())
         self.assertEqual(1, self.count["config_count"])
 
     def test_backup_web_app(self):
@@ -228,16 +166,10 @@ class TestBackupApplications(unittest.TestCase):
         self.app_base_data["value"][0]["@odata.type"] = "#microsoft.graph.webApp"
         self.makeapirequest.return_value = self.app_base_data
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, self.append_id)
 
         self.assertTrue(Path(self.directory.path + "/Applications/Web App").exists())
-        self.assertTrue(
-            Path(
-                self.directory.path + "/Applications/Web App/test_webApp.json"
-            ).exists()
-        )
+        self.assertTrue(Path(self.directory.path + "/Applications/Web App/test_webApp.json").exists())
         self.assertEqual(1, self.count["config_count"])
 
     def test_backup_other_app(self):
@@ -246,24 +178,16 @@ class TestBackupApplications(unittest.TestCase):
         self.app_base_data["value"][0]["@odata.type"] = "#microsoft.graph.macOSother"
         self.makeapirequest.return_value = self.app_base_data
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, self.append_id)
 
         self.assertTrue(Path(self.directory.path + "/Applications/macOS").exists())
-        self.assertTrue(
-            Path(
-                self.directory.path + "/Applications/macOS/test_macOSother.json"
-            ).exists()
-        )
+        self.assertTrue(Path(self.directory.path + "/Applications/macOS/test_macOSother.json").exists())
         self.assertEqual(1, self.count["config_count"])
 
     def test_backup_with_no_returned_data(self):
         """The count should be 0 if no data is returned."""
         self.makeapirequest.return_value = {"value": []}
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, self.append_id)
         self.assertEqual(0, self.count["config_count"])
 
     def test_backup_append_id(self):
@@ -272,15 +196,9 @@ class TestBackupApplications(unittest.TestCase):
         self.app_base_data["value"][0]["@odata.type"] = "#microsoft.graph.iosVppApp"
         self.makeapirequest.return_value = self.app_base_data
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, True
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, True)
 
-        self.assertTrue(
-            Path(
-                self.directory.path + "/Applications/iOS/test_iOSVppApp_test_0.json"
-            ).exists()
-        )
+        self.assertTrue(Path(self.directory.path + "/Applications/iOS/test_iOSVppApp_test__0.json").exists())
 
 
 if __name__ == "__main__":

--- a/tests/Backup/test_backup_assignmentFilter.py
+++ b/tests/Backup/test_backup_assignmentFilter.py
@@ -54,9 +54,7 @@ class TestBackupAssignmentFilters(unittest.TestCase):
     def test_backup_yml(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "yaml", self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "yaml", self.token, "", self.append_id)
 
         with open(self.saved_path + "yaml", "r") as f:
             data = json.dumps(yaml.safe_load(f))
@@ -69,9 +67,7 @@ class TestBackupAssignmentFilters(unittest.TestCase):
     def test_backup_json(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.token, "", self.append_id)
 
         with open(self.saved_path + "json", "r") as f:
             self.saved_data = json.load(f)
@@ -84,18 +80,14 @@ class TestBackupAssignmentFilters(unittest.TestCase):
         """The count should be 0 if no data is returned."""
 
         self.makeapirequest.return_value = {"value": []}
-        self.count = savebackup(
-            self.directory.path, "json", self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.token, "", self.append_id)
         self.assertEqual(0, self.count["config_count"])
 
     def test_backup_with_prefix(self):
         """The count should be 0 if no data is returned."""
 
         self.makeapirequest.return_value = {"value": []}
-        self.count = savebackup(
-            self.directory.path, "json", self.token, "test", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.token, "test", self.append_id)
         self.assertEqual(0, self.count["config_count"])
 
     def test_backup_append_id(self):
@@ -103,9 +95,7 @@ class TestBackupAssignmentFilters(unittest.TestCase):
 
         self.count = savebackup(self.directory.path, "json", self.token, "", True)
 
-        self.assertTrue(
-            Path(f"{self.directory.path}/Filters/macOS - Model_0.json").exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Filters/macOS - Model__0.json").exists())
 
 
 if __name__ == "__main__":

--- a/tests/Backup/test_backup_compliance.py
+++ b/tests/Backup/test_backup_compliance.py
@@ -49,30 +49,22 @@ class TestBackupCompliance(unittest.TestCase):
                     "scheduledActionsForRule": [
                         {
                             "ruleName": None,
-                            "scheduledActionConfigurations": [
-                                {"id": "0", "gracePeriodHours": 0}
-                            ],
+                            "scheduledActionConfigurations": [{"id": "0", "gracePeriodHours": 0}],
                         }
                     ],
                 }
             ]
         }
 
-        self.batch_assignment_patch = patch(
-            "src.IntuneCD.backup_compliance.batch_assignment"
-        )
+        self.batch_assignment_patch = patch("src.IntuneCD.backup_compliance.batch_assignment")
         self.batch_assignment = self.batch_assignment_patch.start()
         self.batch_assignment.return_value = BATCH_ASSIGNMENT
 
-        self.object_assignment_patch = patch(
-            "src.IntuneCD.backup_compliance.get_object_assignment"
-        )
+        self.object_assignment_patch = patch("src.IntuneCD.backup_compliance.get_object_assignment")
         self.object_assignment = self.object_assignment_patch.start()
         self.object_assignment.return_value = OBJECT_ASSIGNMENT
 
-        self.makeapirequest_patch = patch(
-            "src.IntuneCD.backup_compliance.makeapirequest"
-        )
+        self.makeapirequest_patch = patch("src.IntuneCD.backup_compliance.makeapirequest")
         self.makeapirequest = self.makeapirequest_patch.start()
         self.makeapirequest.return_value = self.compliance_policy
 
@@ -86,18 +78,14 @@ class TestBackupCompliance(unittest.TestCase):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
         output = "yaml"
-        count = savebackup(
-            self.directory.path, output, self.exclude, self.token, "", self.append_id
-        )
+        count = savebackup(self.directory.path, output, self.exclude, self.token, "", self.append_id)
 
         with open(self.saved_path + output, "r") as f:
             data = json.dumps(yaml.safe_load(f))
             saved_data = json.loads(data)
 
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
-        self.assertTrue(
-            Path(f"{self.directory.path}/Compliance Policies/Policies").exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Compliance Policies/Policies").exists())
         self.assertEqual(self.expected_data, saved_data)
         self.assertEqual(1, count["config_count"])
 
@@ -105,17 +93,13 @@ class TestBackupCompliance(unittest.TestCase):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
         output = "json"
-        count = savebackup(
-            self.directory.path, output, self.exclude, self.token, "", self.append_id
-        )
+        count = savebackup(self.directory.path, output, self.exclude, self.token, "", self.append_id)
 
         with open(self.saved_path + output, "r") as f:
             saved_data = json.load(f)
 
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
-        self.assertTrue(
-            Path(f"{self.directory.path}/Compliance Policies/Policies").exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Compliance Policies/Policies").exists())
         self.assertEqual(self.expected_data, saved_data)
         self.assertEqual(1, count["config_count"])
 
@@ -123,9 +107,7 @@ class TestBackupCompliance(unittest.TestCase):
         """The count should be 0 if no data is returned."""
 
         self.makeapirequest.return_value = {"value": []}
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", self.append_id)
         self.assertEqual(0, self.count["config_count"])
 
     def test_backup_with_prefix(self):
@@ -145,15 +127,9 @@ class TestBackupCompliance(unittest.TestCase):
     def test_backup_append_id(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", True
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", True)
 
-        self.assertTrue(
-            Path(
-                f"{self.directory.path}/Compliance Policies/Policies/test_iosCompliancePolicy_0.json"
-            ).exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Compliance Policies/Policies/test__iosCompliancePolicy_0.json").exists())
 
 
 if __name__ == "__main__":

--- a/tests/Backup/test_backup_compliance.py
+++ b/tests/Backup/test_backup_compliance.py
@@ -129,7 +129,7 @@ class TestBackupCompliance(unittest.TestCase):
 
         self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", True)
 
-        self.assertTrue(Path(f"{self.directory.path}/Compliance Policies/Policies/test__iosCompliancePolicy_0.json").exists())
+        self.assertTrue(Path(f"{self.directory.path}/Compliance Policies/Policies/test_iosCompliancePolicy__0.json").exists())
 
 
 if __name__ == "__main__":

--- a/tests/Backup/test_backup_compliancePartner.py
+++ b/tests/Backup/test_backup_compliancePartner.py
@@ -70,9 +70,7 @@ class TestBackupCompliancePartner(unittest.TestCase):
             data = json.dumps(yaml.safe_load(f))
             self.saved_data = json.loads(data)
 
-        self.assertTrue(
-            Path(f"{self.directory.path}/Partner Connections/Compliance").exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Partner Connections/Compliance").exists())
         self.assertEqual(self.expected_data, self.saved_data)
         self.assertEqual(1, self.count["config_count"])
 
@@ -84,9 +82,7 @@ class TestBackupCompliancePartner(unittest.TestCase):
         with open(self.saved_path + "json", "r") as f:
             self.saved_data = json.load(f)
 
-        self.assertTrue(
-            Path(f"{self.directory.path}/Partner Connections/Compliance").exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Partner Connections/Compliance").exists())
         self.assertEqual(self.expected_data, self.saved_data)
         self.assertEqual(1, self.count["config_count"])
 
@@ -102,11 +98,7 @@ class TestBackupCompliancePartner(unittest.TestCase):
 
         self.count = savebackup(self.directory.path, "json", self.token, True)
 
-        self.assertTrue(
-            Path(
-                f"{self.directory.path}/Partner Connections/Compliance/test_0.json"
-            ).exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Partner Connections/Compliance/test__0.json").exists())
 
 
 if __name__ == "__main__":

--- a/tests/Backup/test_backup_conditionalAccess.py
+++ b/tests/Backup/test_backup_conditionalAccess.py
@@ -48,14 +48,10 @@ class TestBackupConditionalAccess(unittest.TestCase):
                         "clientAppTypes": ["all"],
                         "applications": {
                             "includeApplications": ["All"],
-                            "excludedApplications": [
-                                "d4ebce55-015a-49b5-a083-c84d1797ae8c"
-                            ],
+                            "excludedApplications": ["d4ebce55-015a-49b5-a083-c84d1797ae8c"],
                         },
                     },
-                    "grantControls": {
-                        "authenticationStrength@odata.context": "context"
-                    },
+                    "grantControls": {"authenticationStrength@odata.context": "context"},
                 }
             ]
         }
@@ -71,9 +67,7 @@ class TestBackupConditionalAccess(unittest.TestCase):
             "grantControls": {},
         }
 
-        self.makeapirequest_patch = patch(
-            "src.IntuneCD.backup_conditionalAccess.makeapirequest"
-        )
+        self.makeapirequest_patch = patch("src.IntuneCD.backup_conditionalAccess.makeapirequest")
         self.makeapirequest = self.makeapirequest_patch.start()
         self.makeapirequest.side_effect = [self.policy, self.policy["value"][0]]
 
@@ -84,9 +78,7 @@ class TestBackupConditionalAccess(unittest.TestCase):
     def test_backup_yml(self, mock_data):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "yaml", self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "yaml", self.token, "", self.append_id)
 
         with open(self.saved_path + "yaml", "r") as f:
             data = json.dumps(yaml.safe_load(f))
@@ -99,9 +91,7 @@ class TestBackupConditionalAccess(unittest.TestCase):
     def test_backup_json(self, mock_data):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.token, "", self.append_id)
 
         with open(self.saved_path + "json", "r") as f:
             self.saved_data = json.load(f)
@@ -114,17 +104,13 @@ class TestBackupConditionalAccess(unittest.TestCase):
         """The count should be 0 if no data is returned."""
 
         self.makeapirequest.side_effect = [{"value": []}]
-        self.count = savebackup(
-            self.directory.path, "json", self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.token, "", self.append_id)
         self.assertEqual(0, self.count["config_count"])
 
     def test_backup_with_prefix(self, mock_data):
         """The count should be 0 if the prefix does not match."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.token, "test1", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.token, "test1", self.append_id)
 
         self.assertEqual(0, self.count["config_count"])
 
@@ -133,9 +119,7 @@ class TestBackupConditionalAccess(unittest.TestCase):
 
         self.count = savebackup(self.directory.path, "json", self.token, "", True)
 
-        self.assertTrue(
-            Path(f"{self.directory.path}/Conditional Access/test_1.json").exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Conditional Access/test__1.json").exists())
 
 
 if __name__ == "__main__":

--- a/tests/Backup/test_backup_configurationPolicies.py
+++ b/tests/Backup/test_backup_configurationPolicies.py
@@ -91,27 +91,19 @@ class TestBackupConfigurationPolicy(unittest.TestCase):
             ]
         }
 
-        self.batch_assignment_patch = patch(
-            "src.IntuneCD.backup_configurationPolicies.batch_assignment"
-        )
+        self.batch_assignment_patch = patch("src.IntuneCD.backup_configurationPolicies.batch_assignment")
         self.batch_assignment = self.batch_assignment_patch.start()
         self.batch_assignment.return_value = BATCH_ASSIGNMENT
 
-        self.batch_request_patch = patch(
-            "src.IntuneCD.backup_configurationPolicies.batch_request"
-        )
+        self.batch_request_patch = patch("src.IntuneCD.backup_configurationPolicies.batch_request")
         self.batch_request = self.batch_request_patch.start()
         self.batch_request.return_value = BATCH_REQUEST
 
-        self.object_assignment_patch = patch(
-            "src.IntuneCD.backup_configurationPolicies.get_object_assignment"
-        )
+        self.object_assignment_patch = patch("src.IntuneCD.backup_configurationPolicies.get_object_assignment")
         self.object_assignment = self.object_assignment_patch.start()
         self.object_assignment.return_value = OBJECT_ASSIGNMENT
 
-        self.makeapirequest_patch = patch(
-            "src.IntuneCD.backup_configurationPolicies.makeapirequest"
-        )
+        self.makeapirequest_patch = patch("src.IntuneCD.backup_configurationPolicies.makeapirequest")
         self.makeapirequest = self.makeapirequest_patch.start()
         self.makeapirequest.return_value = self.configuration_policy
 
@@ -125,9 +117,7 @@ class TestBackupConfigurationPolicy(unittest.TestCase):
     def test_backup_yml(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "yaml", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "yaml", self.exclude, self.token, "", self.append_id)
 
         with open(self.saved_path + "yaml", "r") as f:
             data = json.dumps(yaml.safe_load(f))
@@ -140,9 +130,7 @@ class TestBackupConfigurationPolicy(unittest.TestCase):
     def test_backup_json(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", self.append_id)
 
         with open(self.saved_path + "json", "r") as f:
             self.saved_data = json.load(f)
@@ -155,9 +143,7 @@ class TestBackupConfigurationPolicy(unittest.TestCase):
         """The count should be 0 if no data is returned."""
 
         self.makeapirequest.return_value = {"value": []}
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", self.append_id)
         self.assertEqual(0, self.count["config_count"])
 
     def test_backup_with_prefix(self):
@@ -177,13 +163,9 @@ class TestBackupConfigurationPolicy(unittest.TestCase):
     def test_backup_append_id(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", True
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", True)
 
-        self.assertTrue(
-            Path(f"{self.directory.path}/Settings Catalog/test_test_0.json").exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Settings Catalog/test_test__0.json").exists())
 
 
 if __name__ == "__main__":

--- a/tests/Backup/test_backup_customAttributeShellScript.py
+++ b/tests/Backup/test_backup_customAttributeShellScript.py
@@ -25,9 +25,7 @@ class TestBackupCustomAttributeShellScript(unittest.TestCase):
         self.exclude = []
         self.append_id = False
         self.saved_path = f"{self.directory.path}/Custom Attributes/test."
-        self.script_content_path = (
-            f"{self.directory.path}/Custom Attributes/Script Data/test.ps1"
-        )
+        self.script_content_path = f"{self.directory.path}/Custom Attributes/Script Data/test.ps1"
         self.expected_data = {
             "assignments": [{"target": {"groupName": "Group1"}}],
             "displayName": "test",
@@ -44,27 +42,19 @@ class TestBackupCustomAttributeShellScript(unittest.TestCase):
             }
         ]
 
-        self.batch_assignment_patch = patch(
-            "src.IntuneCD.backup_customAttributeShellScript.batch_assignment"
-        )
+        self.batch_assignment_patch = patch("src.IntuneCD.backup_customAttributeShellScript.batch_assignment")
         self.batch_assignment = self.batch_assignment_patch.start()
         self.batch_assignment.return_value = BATCH_ASSIGNMENT
 
-        self.object_assignment_patch = patch(
-            "src.IntuneCD.backup_customAttributeShellScript.get_object_assignment"
-        )
+        self.object_assignment_patch = patch("src.IntuneCD.backup_customAttributeShellScript.get_object_assignment")
         self.object_assignment = self.object_assignment_patch.start()
         self.object_assignment.return_value = OBJECT_ASSIGNMENT
 
-        self.batch_request_patch = patch(
-            "src.IntuneCD.backup_customAttributeShellScript.batch_request"
-        )
+        self.batch_request_patch = patch("src.IntuneCD.backup_customAttributeShellScript.batch_request")
         self.batch_request = self.batch_request_patch.start()
         self.batch_request.return_value = self.batch_request_data
 
-        self.makeapirequest_patch = patch(
-            "src.IntuneCD.backup_customAttributeShellScript.makeapirequest"
-        )
+        self.makeapirequest_patch = patch("src.IntuneCD.backup_customAttributeShellScript.makeapirequest")
         self.makeapirequest = self.makeapirequest_patch.start()
         self.makeapirequest.return_value = self.script_policy_data
 
@@ -78,9 +68,7 @@ class TestBackupCustomAttributeShellScript(unittest.TestCase):
     def test_backup_yml(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "yaml", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "yaml", self.exclude, self.token, "", self.append_id)
 
         with open(self.saved_path + "yaml", "r") as f:
             data = json.dumps(yaml.safe_load(f))
@@ -93,9 +81,7 @@ class TestBackupCustomAttributeShellScript(unittest.TestCase):
     def test_backup_json(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", self.append_id)
 
         with open(self.saved_path + "json", "r") as f:
             self.saved_data = json.load(f)
@@ -107,9 +93,7 @@ class TestBackupCustomAttributeShellScript(unittest.TestCase):
     def test_script_is_created(self):
         """The folder should be created and a .ps1 file should be created."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", self.append_id)
 
         self.assertTrue(f"{self.directory.path}/Custom Attributes/Script Data")
         self.assertTrue(self.script_content_path)
@@ -119,9 +103,7 @@ class TestBackupCustomAttributeShellScript(unittest.TestCase):
         """The count should be 0 if no data is returned."""
 
         self.batch_request.return_value = []
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", self.append_id)
 
         self.assertEqual(0, self.count["config_count"])
 
@@ -142,13 +124,9 @@ class TestBackupCustomAttributeShellScript(unittest.TestCase):
     def test_backup_append_id(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", True
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", True)
 
-        self.assertTrue(
-            Path(f"{self.directory.path}/Custom Attributes/test_0.json").exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Custom Attributes/test__0.json").exists())
 
 
 if __name__ == "__main__":

--- a/tests/Backup/test_backup_deviceCategories.py
+++ b/tests/Backup/test_backup_deviceCategories.py
@@ -51,9 +51,7 @@ class TestBackupdeviceCategories(unittest.TestCase):
     def test_backup_yml(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "yaml", self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "yaml", self.token, "", self.append_id)
 
         with open(self.saved_path + "yaml", "r") as f:
             data = json.dumps(yaml.safe_load(f))
@@ -66,9 +64,7 @@ class TestBackupdeviceCategories(unittest.TestCase):
     def test_backup_json(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.token, "", self.append_id)
 
         with open(self.saved_path + "json", "r") as f:
             saved_data = json.load(f)
@@ -81,18 +77,14 @@ class TestBackupdeviceCategories(unittest.TestCase):
         """The count should be 0 if no data is returned."""
 
         self.makeapirequest.return_value = {"value": []}
-        self.count = savebackup(
-            self.directory.path, "json", self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.token, "", self.append_id)
         self.assertEqual(0, self.count["config_count"])
 
     def test_backup_with_prefix(self):
         """The count should be 0 if no data is returned."""
 
         self.makeapirequest.return_value = {"value": []}
-        self.count = savebackup(
-            self.directory.path, "json", self.token, "test", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.token, "test", self.append_id)
         self.assertEqual(0, self.count["config_count"])
 
     def test_backup_append_id(self):
@@ -101,9 +93,7 @@ class TestBackupdeviceCategories(unittest.TestCase):
         self.count = savebackup(self.directory.path, "json", self.token, "", True)
 
         self.assertTrue(
-            Path(
-                f"{self.directory.path}/Device Categories/Test_00000000-0000-0000-0000-000000000000.json"
-            ).exists()
+            Path(f"{self.directory.path}/Device Categories/Test__00000000-0000-0000-0000-000000000000.json").exists()
         )
 
 

--- a/tests/Backup/test_backup_enrollmentConfigurations.py
+++ b/tests/Backup/test_backup_enrollmentConfigurations.py
@@ -48,21 +48,15 @@ class TestBackupEnrollmentConfigurations(unittest.TestCase):
             ]
         }
 
-        self.batch_assignment_patch = patch(
-            "src.IntuneCD.backup_enrollmentConfigurations.batch_assignment"
-        )
+        self.batch_assignment_patch = patch("src.IntuneCD.backup_enrollmentConfigurations.batch_assignment")
         self.batch_assignment = self.batch_assignment_patch.start()
         self.batch_assignment.return_value = BATCH_ASSIGNMENT
 
-        self.object_assignment_patch = patch(
-            "src.IntuneCD.backup_enrollmentConfigurations.get_object_assignment"
-        )
+        self.object_assignment_patch = patch("src.IntuneCD.backup_enrollmentConfigurations.get_object_assignment")
         self.object_assignment = self.object_assignment_patch.start()
         self.object_assignment.return_value = OBJECT_ASSIGNMENT
 
-        self.makeapirequest_patch = patch(
-            "src.IntuneCD.backup_enrollmentConfigurations.makeapirequest"
-        )
+        self.makeapirequest_patch = patch("src.IntuneCD.backup_enrollmentConfigurations.makeapirequest")
         self.makeapirequest = self.makeapirequest_patch.start()
         self.makeapirequest.return_value = self.enrollment_config
 
@@ -75,9 +69,7 @@ class TestBackupEnrollmentConfigurations(unittest.TestCase):
     def test_backup_yml(self):
         """Test that the backup is saved as yml. And that the data is correct."""
         output = "yaml"
-        count = savebackup(
-            self.directory.path, output, self.exclude, self.token, "", self.append_id
-        )
+        count = savebackup(self.directory.path, output, self.exclude, self.token, "", self.append_id)
         with open(f"{self.saved_path}yaml", "r") as file:
             data = yaml.safe_load(file)
         self.assertEqual(data, self.expected_data)
@@ -85,9 +77,7 @@ class TestBackupEnrollmentConfigurations(unittest.TestCase):
     def test_backup_json(self):
         """Test that the backup is saved as json. And that the data is correct."""
         output = "json"
-        count = savebackup(
-            self.directory.path, output, self.exclude, self.token, "", self.append_id
-        )
+        count = savebackup(self.directory.path, output, self.exclude, self.token, "", self.append_id)
         with open(f"{self.saved_path}json", "r") as file:
             data = yaml.safe_load(file)
         self.assertEqual(data, self.expected_data)
@@ -95,12 +85,8 @@ class TestBackupEnrollmentConfigurations(unittest.TestCase):
     def test_backup_skip_ESP(self):
         """Test that the backup is skipped when config is ESP."""
         output = "json"
-        self.enrollment_config["value"][0][
-            "@odata.type"
-        ] = "#microsoft.graph.windows10EnrollmentCompletionPageConfiguration"
-        count = savebackup(
-            self.directory.path, output, self.exclude, self.token, "", self.append_id
-        )
+        self.enrollment_config["value"][0]["@odata.type"] = "#microsoft.graph.windows10EnrollmentCompletionPageConfiguration"
+        count = savebackup(self.directory.path, output, self.exclude, self.token, "", self.append_id)
 
         self.assertEqual(0, count["config_count"])
 
@@ -108,9 +94,7 @@ class TestBackupEnrollmentConfigurations(unittest.TestCase):
         """The count should be 0 if no data is returned."""
 
         self.makeapirequest.side_effect = [{"value": []}]
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", self.append_id)
 
         self.assertEqual(0, self.count["config_count"])
 
@@ -130,15 +114,9 @@ class TestBackupEnrollmentConfigurations(unittest.TestCase):
     def test_backup_append_id(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", True
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", True)
 
-        self.assertTrue(
-            Path(
-                f"{self.directory.path}/Enrollment Configurations/test_test_test.json"
-            ).exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Enrollment Configurations/test_test__test.json").exists())
 
 
 if __name__ == "__main__":

--- a/tests/Backup/test_backup_enrollmentStatusPage.py
+++ b/tests/Backup/test_backup_enrollmentStatusPage.py
@@ -28,9 +28,7 @@ class TestBackupEnrollmentStatusPage(unittest.TestCase):
         self.expected_data = {
             "assignments": [{"target": {"groupName": "Group1"}}],
             "displayName": "test",
-            "selectedMobileAppNames": [
-                {"name": "app1", "type": "#microsoft.graph.mobileApp"}
-            ],
+            "selectedMobileAppNames": [{"name": "app1", "type": "#microsoft.graph.mobileApp"}],
             "@odata.type": "#microsoft.graph.windows10EnrollmentCompletionPageConfiguration",
         }
         self.statuspage_profile = {
@@ -48,21 +46,15 @@ class TestBackupEnrollmentStatusPage(unittest.TestCase):
             "@odata.type": "#microsoft.graph.mobileApp",
         }
 
-        self.batch_assignment_patch = patch(
-            "src.IntuneCD.backup_enrollmentStatusPage.batch_assignment"
-        )
+        self.batch_assignment_patch = patch("src.IntuneCD.backup_enrollmentStatusPage.batch_assignment")
         self.batch_assignment = self.batch_assignment_patch.start()
         self.batch_assignment.return_value = BATCH_ASSIGNMENT
 
-        self.object_assignment_patch = patch(
-            "src.IntuneCD.backup_enrollmentStatusPage.get_object_assignment"
-        )
+        self.object_assignment_patch = patch("src.IntuneCD.backup_enrollmentStatusPage.get_object_assignment")
         self.object_assignment = self.object_assignment_patch.start()
         self.object_assignment.return_value = OBJECT_ASSIGNMENT
 
-        self.makeapirequest_patch = patch(
-            "src.IntuneCD.backup_enrollmentStatusPage.makeapirequest"
-        )
+        self.makeapirequest_patch = patch("src.IntuneCD.backup_enrollmentStatusPage.makeapirequest")
         self.makeapirequest = self.makeapirequest_patch.start()
         self.makeapirequest.side_effect = self.statuspage_profile, self.app_data
 
@@ -76,9 +68,7 @@ class TestBackupEnrollmentStatusPage(unittest.TestCase):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
         output = "yaml"
-        count = savebackup(
-            self.directory.path, output, self.exclude, self.token, "", self.append_id
-        )
+        count = savebackup(self.directory.path, output, self.exclude, self.token, "", self.append_id)
 
         with open(self.saved_path + output, "r") as f:
             data = json.dumps(yaml.safe_load(f))
@@ -92,9 +82,7 @@ class TestBackupEnrollmentStatusPage(unittest.TestCase):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
         output = "json"
-        count = savebackup(
-            self.directory.path, output, self.exclude, self.token, "", self.append_id
-        )
+        count = savebackup(self.directory.path, output, self.exclude, self.token, "", self.append_id)
 
         with open(self.saved_path + output, "r") as f:
             saved_data = json.load(f)
@@ -107,9 +95,7 @@ class TestBackupEnrollmentStatusPage(unittest.TestCase):
         """The count should be 0 if no data is returned."""
 
         self.makeapirequest.side_effect = [{"value": []}]
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", self.append_id)
 
         self.assertEqual(0, self.count["config_count"])
 
@@ -129,15 +115,9 @@ class TestBackupEnrollmentStatusPage(unittest.TestCase):
     def test_backup_append_id(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", True
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", True)
 
-        self.assertTrue(
-            Path(
-                f"{self.directory.path}/Enrollment Profiles/Windows/ESP/test_0.json"
-            ).exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Enrollment Profiles/Windows/ESP/test__0.json").exists())
 
 
 if __name__ == "__main__":

--- a/tests/Backup/test_backup_groupPolicyConfiguration.py
+++ b/tests/Backup/test_backup_groupPolicyConfiguration.py
@@ -64,21 +64,15 @@ class TestBackupGroupPolicyConfiguration(unittest.TestCase):
         }
         self.presentations = {"value": []}
 
-        self.batch_assignment_patch = patch(
-            "src.IntuneCD.backup_groupPolicyConfiguration.batch_assignment"
-        )
+        self.batch_assignment_patch = patch("src.IntuneCD.backup_groupPolicyConfiguration.batch_assignment")
         self.batch_assignment = self.batch_assignment_patch.start()
         self.batch_assignment.return_value = BATCH_ASSIGNMENT
 
-        self.object_assignment_patch = patch(
-            "src.IntuneCD.backup_groupPolicyConfiguration.get_object_assignment"
-        )
+        self.object_assignment_patch = patch("src.IntuneCD.backup_groupPolicyConfiguration.get_object_assignment")
         self.object_assignment = self.object_assignment_patch.start()
         self.object_assignment.return_value = OBJECT_ASSIGNMENT
 
-        self.makeapirequest_patch = patch(
-            "src.IntuneCD.backup_groupPolicyConfiguration.makeapirequest"
-        )
+        self.makeapirequest_patch = patch("src.IntuneCD.backup_groupPolicyConfiguration.makeapirequest")
         self.makeapirequest = self.makeapirequest_patch.start()
         self.makeapirequest.side_effect = (
             self.group_policy,
@@ -95,33 +89,25 @@ class TestBackupGroupPolicyConfiguration(unittest.TestCase):
     def test_backup_yml(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "yaml", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "yaml", self.exclude, self.token, "", self.append_id)
 
         with open(self.saved_path + "yaml", "r") as f:
             data = json.dumps(yaml.safe_load(f))
             saved_data = json.loads(data)
 
-        self.assertTrue(
-            Path(f"{self.directory.path}/Group Policy Configurations").exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Group Policy Configurations").exists())
         self.assertEqual(self.expected_data, saved_data)
         self.assertEqual(1, self.count["config_count"])
 
     def test_backup_json(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", self.append_id)
 
         with open(self.saved_path + "json", "r") as f:
             saved_data = json.load(f)
 
-        self.assertTrue(
-            Path(f"{self.directory.path}/Group Policy Configurations").exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Group Policy Configurations").exists())
         self.assertEqual(self.expected_data, saved_data)
         self.assertEqual(1, self.count["config_count"])
 
@@ -129,9 +115,7 @@ class TestBackupGroupPolicyConfiguration(unittest.TestCase):
         """The count should be 0 if no data is returned."""
 
         self.makeapirequest.side_effect = [{"value": []}]
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", self.append_id)
 
         self.assertEqual(0, self.count["config_count"])
 
@@ -151,15 +135,9 @@ class TestBackupGroupPolicyConfiguration(unittest.TestCase):
     def test_backup_append_id(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", True
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", True)
 
-        self.assertTrue(
-            Path(
-                f"{self.directory.path}/Group Policy Configurations/test_0.json"
-            ).exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Group Policy Configurations/test__0.json").exists())
 
 
 if __name__ == "__main__":

--- a/tests/Backup/test_backup_managedGPlay.py
+++ b/tests/Backup/test_backup_managedGPlay.py
@@ -20,9 +20,7 @@ class TestBackupManagedGPlay(unittest.TestCase):
         self.directory.create()
         self.token = "token"
         self.append_id = False
-        self.saved_path = (
-            f"{self.directory.path}/Managed Google Play/awesome@gmail.com."
-        )
+        self.saved_path = f"{self.directory.path}/Managed Google Play/awesome@gmail.com."
         self.expected_data = {
             "bindStatus": "boundAndValidated",
             "lastAppSyncDateTime": "2022-01-28T12:28:48.975089Z",
@@ -84,11 +82,7 @@ class TestBackupManagedGPlay(unittest.TestCase):
 
         self.count = savebackup(self.directory.path, "json", self.token, True)
 
-        self.assertTrue(
-            Path(
-                f"{self.directory.path}/Managed Google Play/awesome@gmail.com_0.json"
-            ).exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Managed Google Play/awesome@gmail.com__0.json").exists())
 
 
 if __name__ == "__main__":

--- a/tests/Backup/test_backup_managementIntents.py
+++ b/tests/Backup/test_backup_managementIntents.py
@@ -62,27 +62,19 @@ class TestBackupManagementIntent(unittest.TestCase):
             ]
         }
 
-        self.batch_intent_patch = patch(
-            "src.IntuneCD.backup_managementIntents.batch_intents"
-        )
+        self.batch_intent_patch = patch("src.IntuneCD.backup_managementIntents.batch_intents")
         self.batch_intent = self.batch_intent_patch.start()
         self.batch_intent.return_value = self.batch_intent_data
 
-        self.batch_assignment_patch = patch(
-            "src.IntuneCD.backup_managementIntents.batch_assignment"
-        )
+        self.batch_assignment_patch = patch("src.IntuneCD.backup_managementIntents.batch_assignment")
         self.batch_assignment = self.batch_assignment_patch.start()
         self.batch_assignment.return_value = BATCH_ASSIGNMENT
 
-        self.object_assignment_patch = patch(
-            "src.IntuneCD.backup_managementIntents.get_object_assignment"
-        )
+        self.object_assignment_patch = patch("src.IntuneCD.backup_managementIntents.get_object_assignment")
         self.object_assignment = self.object_assignment_patch.start()
         self.object_assignment.return_value = OBJECT_ASSIGNMENT
 
-        self.makeapirequest_patch = patch(
-            "src.IntuneCD.backup_managementIntents.makeapirequest"
-        )
+        self.makeapirequest_patch = patch("src.IntuneCD.backup_managementIntents.makeapirequest")
         self.makeapirequest = self.makeapirequest_patch.start()
         self.makeapirequest.side_effect = self.intent, self.template
 
@@ -96,33 +88,25 @@ class TestBackupManagementIntent(unittest.TestCase):
     def test_backup_yml(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "yaml", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "yaml", self.exclude, self.token, "", self.append_id)
 
         with open(self.saved_path + "yaml", "r") as f:
             data = json.dumps(yaml.safe_load(f))
             saved_data = json.loads(data)
 
-        self.assertTrue(
-            Path(f"{self.directory.path}/Management Intents/Dummy Intent").exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Management Intents/Dummy Intent").exists())
         self.assertEqual(self.expected_data, saved_data)
         self.assertEqual(1, self.count["config_count"])
 
     def test_backup_json(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", self.append_id)
 
         with open(self.saved_path + "json", "r") as f:
             saved_data = json.load(f)
 
-        self.assertTrue(
-            Path(f"{self.directory.path}/Management Intents/Dummy Intent").exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Management Intents/Dummy Intent").exists())
         self.assertEqual(self.expected_data, saved_data)
         self.assertEqual(1, self.count["config_count"])
 
@@ -130,9 +114,7 @@ class TestBackupManagementIntent(unittest.TestCase):
         """The count should be 0 if no data is returned."""
 
         self.batch_intent.return_value = {"value": []}
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", self.append_id)
 
         self.assertEqual(0, self.count["config_count"])
 
@@ -152,15 +134,9 @@ class TestBackupManagementIntent(unittest.TestCase):
     def test_backup_append_id(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", True
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", True)
 
-        self.assertTrue(
-            Path(
-                f"{self.directory.path}/Management Intents/Dummy Intent/test_0.json"
-            ).exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Management Intents/Dummy Intent/test__0.json").exists())
 
 
 if __name__ == "__main__":

--- a/tests/Backup/test_backup_managementPartner.py
+++ b/tests/Backup/test_backup_managementPartner.py
@@ -56,9 +56,7 @@ class TestBackupManagementPartner(unittest.TestCase):
             data = json.dumps(yaml.safe_load(f))
             self.saved_data = json.loads(data)
 
-        self.assertTrue(
-            Path(f"{self.directory.path}/Partner Connections/Management").exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Partner Connections/Management").exists())
         self.assertEqual(self.expected_data, self.saved_data)
         self.assertEqual(1, self.count["config_count"])
 
@@ -70,9 +68,7 @@ class TestBackupManagementPartner(unittest.TestCase):
         with open(self.saved_path + "json", "r") as f:
             self.saved_data = json.load(f)
 
-        self.assertTrue(
-            Path(f"{self.directory.path}/Partner Connections/Management").exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Partner Connections/Management").exists())
         self.assertEqual(self.expected_data, self.saved_data)
         self.assertEqual(1, self.count["config_count"])
 
@@ -88,11 +84,7 @@ class TestBackupManagementPartner(unittest.TestCase):
 
         self.count = savebackup(self.directory.path, "json", self.token, True)
 
-        self.assertTrue(
-            Path(
-                f"{self.directory.path}/Partner Connections/Management/test_0.json"
-            ).exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Partner Connections/Management/test__0.json").exists())
 
 
 if __name__ == "__main__":

--- a/tests/Backup/test_backup_notificationTemplate.py
+++ b/tests/Backup/test_backup_notificationTemplate.py
@@ -20,9 +20,7 @@ class TestBackupNotificationTemplate(unittest.TestCase):
         self.directory.create()
         self.token = "token"
         self.append_id = False
-        self.saved_path = (
-            f"{self.directory.path}/Compliance Policies/Message Templates/test."
-        )
+        self.saved_path = f"{self.directory.path}/Compliance Policies/Message Templates/test."
         self.expected_data = {
             "brandingOptions": "includeCompanyLogo,includeCompanyName,includeContactInformation",
             "defaultLocale": "da-dk",
@@ -90,37 +88,25 @@ class TestBackupNotificationTemplate(unittest.TestCase):
     def test_backup_yml(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "yaml", self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "yaml", self.token, "", self.append_id)
 
         with open(self.saved_path + "yaml", "r") as f:
             data = json.dumps(yaml.safe_load(f))
             saved_data = json.loads(data)
 
-        self.assertTrue(
-            Path(
-                f"{self.directory.path}/Compliance Policies/Message Templates"
-            ).exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Compliance Policies/Message Templates").exists())
         self.assertEqual(self.expected_data, saved_data)
         self.assertEqual(1, self.count["config_count"])
 
     def test_backup_json(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.token, "", self.append_id)
 
         with open(self.saved_path + "json", "r") as f:
             saved_data = json.load(f)
 
-        self.assertTrue(
-            Path(
-                f"{self.directory.path}/Compliance Policies/Message Templates"
-            ).exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Compliance Policies/Message Templates").exists())
         self.assertEqual(self.expected_data, saved_data)
         self.assertEqual(1, self.count["config_count"])
 
@@ -128,17 +114,13 @@ class TestBackupNotificationTemplate(unittest.TestCase):
         """The count should be 0 if no data is returned."""
 
         self.makeapirequest.side_effect = [{"value": []}]
-        self.count = savebackup(
-            self.directory.path, "json", self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.token, "", self.append_id)
         self.assertEqual(0, self.count["config_count"])
 
     def test_backup_with_prefix(self):
         """The count should be 0 if no data is returned."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.token, "test1", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.token, "test1", self.append_id)
         self.assertEqual(0, self.count["config_count"])
 
     def test_backup_append_id(self):
@@ -146,11 +128,7 @@ class TestBackupNotificationTemplate(unittest.TestCase):
 
         self.count = savebackup(self.directory.path, "json", self.token, "", True)
 
-        self.assertTrue(
-            Path(
-                f"{self.directory.path}/Compliance Policies/Message Templates/test_0.json"
-            ).exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Compliance Policies/Message Templates/test__0.json").exists())
 
 
 if __name__ == "__main__":

--- a/tests/Backup/test_backup_powershellScripts.py
+++ b/tests/Backup/test_backup_powershellScripts.py
@@ -25,9 +25,7 @@ class TestBackupPowershellScript(unittest.TestCase):
         self.exclude = []
         self.append_id = False
         self.saved_path = f"{self.directory.path}/Scripts/Powershell/test."
-        self.script_content_path = (
-            f"{self.directory.path}/Scripts/Powershell/Script Data/test.ps1"
-        )
+        self.script_content_path = f"{self.directory.path}/Scripts/Powershell/Script Data/test.ps1"
         self.expected_data = {
             "assignments": [{"target": {"groupName": "Group1"}}],
             "displayName": "test",
@@ -44,27 +42,19 @@ class TestBackupPowershellScript(unittest.TestCase):
             }
         ]
 
-        self.batch_assignment_patch = patch(
-            "src.IntuneCD.backup_powershellScripts.batch_assignment"
-        )
+        self.batch_assignment_patch = patch("src.IntuneCD.backup_powershellScripts.batch_assignment")
         self.batch_assignment = self.batch_assignment_patch.start()
         self.batch_assignment.return_value = BATCH_ASSIGNMENT
 
-        self.object_assignment_patch = patch(
-            "src.IntuneCD.backup_powershellScripts.get_object_assignment"
-        )
+        self.object_assignment_patch = patch("src.IntuneCD.backup_powershellScripts.get_object_assignment")
         self.object_assignment = self.object_assignment_patch.start()
         self.object_assignment.return_value = OBJECT_ASSIGNMENT
 
-        self.batch_request_patch = patch(
-            "src.IntuneCD.backup_powershellScripts.batch_request"
-        )
+        self.batch_request_patch = patch("src.IntuneCD.backup_powershellScripts.batch_request")
         self.batch_request = self.batch_request_patch.start()
         self.batch_request.return_value = self.batch_request_data
 
-        self.makeapirequest_patch = patch(
-            "src.IntuneCD.backup_powershellScripts.makeapirequest"
-        )
+        self.makeapirequest_patch = patch("src.IntuneCD.backup_powershellScripts.makeapirequest")
         self.makeapirequest = self.makeapirequest_patch.start()
         self.makeapirequest.return_value = self.script_policy_data
 
@@ -78,9 +68,7 @@ class TestBackupPowershellScript(unittest.TestCase):
     def test_backup_yml(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "yaml", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "yaml", self.exclude, self.token, "", self.append_id)
 
         with open(self.saved_path + "yaml", "r") as f:
             data = json.dumps(yaml.safe_load(f))
@@ -94,9 +82,7 @@ class TestBackupPowershellScript(unittest.TestCase):
     def test_backup_json(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", self.append_id)
 
         with open(self.saved_path + "json", "r") as f:
             self.saved_data = json.load(f)
@@ -108,13 +94,9 @@ class TestBackupPowershellScript(unittest.TestCase):
     def test_script_is_created(self):
         """The script data folder should be created and a .ps1 file should be created."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", self.append_id)
 
-        self.assertTrue(
-            Path(f"{self.directory.path}/Scripts/Powershell/Script Data").exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Scripts/Powershell/Script Data").exists())
         self.assertTrue(self.script_content_path)
         self.assertEqual(1, self.count["config_count"])
 
@@ -122,9 +104,7 @@ class TestBackupPowershellScript(unittest.TestCase):
         """The count should be 0 if no data is returned."""
 
         self.makeapirequest.return_value = {"value": []}
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", self.append_id)
 
         self.assertEqual(0, self.count["config_count"])
 
@@ -144,13 +124,10 @@ class TestBackupPowershellScript(unittest.TestCase):
     def test_backup_append_id(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", True
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", True)
 
-        self.assertTrue(
-            Path(f"{self.directory.path}/Scripts/Powershell/test_0.json").exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Scripts/Powershell/test__0.json").exists())
+        self.assertTrue(Path(f"{self.directory.path}/Scripts/Powershell/Script Data/test__0.ps1").exists())
 
 
 if __name__ == "__main__":

--- a/tests/Backup/test_backup_proactiveRemediation.py
+++ b/tests/Backup/test_backup_proactiveRemediation.py
@@ -45,27 +45,19 @@ class TestBackupProactiveRemediation(unittest.TestCase):
             }
         ]
 
-        self.batch_assignment_patch = patch(
-            "src.IntuneCD.backup_proactiveRemediation.batch_assignment"
-        )
+        self.batch_assignment_patch = patch("src.IntuneCD.backup_proactiveRemediation.batch_assignment")
         self.batch_assignment = self.batch_assignment_patch.start()
         self.batch_assignment.return_value = BATCH_ASSIGNMENT
 
-        self.object_assignment_patch = patch(
-            "src.IntuneCD.backup_proactiveRemediation.get_object_assignment"
-        )
+        self.object_assignment_patch = patch("src.IntuneCD.backup_proactiveRemediation.get_object_assignment")
         self.object_assignment = self.object_assignment_patch.start()
         self.object_assignment.return_value = OBJECT_ASSIGNMENT
 
-        self.batch_request_patch = patch(
-            "src.IntuneCD.backup_proactiveRemediation.batch_request"
-        )
+        self.batch_request_patch = patch("src.IntuneCD.backup_proactiveRemediation.batch_request")
         self.batch_request = self.batch_request_patch.start()
         self.batch_request.return_value = self.batch_request_data
 
-        self.makeapirequest_patch = patch(
-            "src.IntuneCD.backup_proactiveRemediation.makeapirequest"
-        )
+        self.makeapirequest_patch = patch("src.IntuneCD.backup_proactiveRemediation.makeapirequest")
         self.makeapirequest = self.makeapirequest_patch.start()
         self.makeapirequest.return_value = self.script_policy_data
 
@@ -79,9 +71,7 @@ class TestBackupProactiveRemediation(unittest.TestCase):
     def test_backup_yml(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "yaml", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "yaml", self.exclude, self.token, "", self.append_id)
 
         with open(self.saved_path + "yaml", "r") as f:
             data = json.dumps(yaml.safe_load(f))
@@ -94,9 +84,7 @@ class TestBackupProactiveRemediation(unittest.TestCase):
     def test_backup_json(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", self.append_id)
 
         with open(self.saved_path + "json", "r") as f:
             self.saved_data = json.load(f)
@@ -108,9 +96,7 @@ class TestBackupProactiveRemediation(unittest.TestCase):
     def test_detection_script_is_created(self):
         """The folder should be created and a .ps1 file should be created."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", self.append_id)
 
         self.assertTrue(f"{self.directory.path}/Proactive Remediations/Script Data")
         self.assertTrue(self.detection_script_path)
@@ -118,9 +104,7 @@ class TestBackupProactiveRemediation(unittest.TestCase):
     def test_remediation_script_is_created(self):
         """The folder should be created and a .ps1 file should be created."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", self.append_id)
 
         self.assertTrue(f"{self.directory.path}/Proactive Remediations/Script Data")
         self.assertTrue(self.remediation_script_path)
@@ -177,16 +161,10 @@ class TestBackupProactiveRemediation(unittest.TestCase):
     def test_backup_append_id(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", True
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", True)
 
-        self.assertTrue(
-            Path(f"{self.directory.path}/Proactive Remediations/test_0.json").exists()
-        )
-        self.assertTrue(
-            Path(f"{self.directory.path}/Proactive Remediations/Script Data/test_DetectionScript_0.ps1").exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Proactive Remediations/test__0.json").exists())
+        self.assertTrue(Path(f"{self.directory.path}/Proactive Remediations/Script Data/test_DetectionScript__0.ps1").exists())
 
 
 if __name__ == "__main__":

--- a/tests/Backup/test_backup_profiles.py
+++ b/tests/Backup/test_backup_profiles.py
@@ -24,15 +24,11 @@ class TestBackupProfiles(unittest.TestCase):
         self.exclude = []
         self.append_id = False
 
-        self.batch_assignment_patch = patch(
-            "src.IntuneCD.backup_profiles.batch_assignment"
-        )
+        self.batch_assignment_patch = patch("src.IntuneCD.backup_profiles.batch_assignment")
         self.batch_assignment = self.batch_assignment_patch.start()
         self.batch_assignment.return_value = BATCH_ASSIGNMENT
 
-        self.object_assignment_patch = patch(
-            "src.IntuneCD.backup_profiles.get_object_assignment"
-        )
+        self.object_assignment_patch = patch("src.IntuneCD.backup_profiles.get_object_assignment")
         self.object_assignment = self.object_assignment_patch.start()
         self.object_assignment.return_value = OBJECT_ASSIGNMENT
 
@@ -60,20 +56,10 @@ class TestBackupProfiles(unittest.TestCase):
             ]
         }
 
-        self.count = savebackup(
-            self.directory.path, "json", self.token, self.exclude, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.token, self.exclude, "", self.append_id)
 
-        self.assertTrue(
-            Path(
-                f"{self.directory.path}/Device Configurations/test_macOSCustomConfiguration.json"
-            ).exists()
-        )
-        self.assertTrue(
-            Path(
-                f"{self.directory.path}/Device Configurations/mobileconfig/test.mobileconfig"
-            ).exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Device Configurations/test_macOSCustomConfiguration.json").exists())
+        self.assertTrue(Path(f"{self.directory.path}/Device Configurations/mobileconfig/test.mobileconfig").exists())
         self.assertEqual(2, self.count["config_count"])
 
     def test_backup_ios_custom_profile(self):
@@ -91,20 +77,10 @@ class TestBackupProfiles(unittest.TestCase):
             ]
         }
 
-        self.count = savebackup(
-            self.directory.path, "json", self.token, self.exclude, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.token, self.exclude, "", self.append_id)
 
-        self.assertTrue(
-            Path(
-                f"{self.directory.path}/Device Configurations/test_iosCustomConfiguration.json"
-            ).exists()
-        )
-        self.assertTrue(
-            Path(
-                f"{self.directory.path}/Device Configurations/mobileconfig/test.mobileconfig"
-            ).exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Device Configurations/test_iosCustomConfiguration.json").exists())
+        self.assertTrue(Path(f"{self.directory.path}/Device Configurations/mobileconfig/test.mobileconfig").exists())
         self.assertEqual(2, self.count["config_count"])
 
     def test_backup_windows_custom_profile_encrypted(self):
@@ -137,15 +113,9 @@ class TestBackupProfiles(unittest.TestCase):
 
         self.makeapirequest.side_effect = self.profile, self.oma_values
 
-        self.count = savebackup(
-            self.directory.path, "json", self.token, self.exclude, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.token, self.exclude, "", self.append_id)
 
-        self.assertTrue(
-            Path(
-                f"{self.directory.path}/Device Configurations/test_windows10CustomConfiguration.json"
-            ).exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Device Configurations/test_windows10CustomConfiguration.json").exists())
         self.assertEqual(1, self.count["config_count"])
 
     def test_backup_windows_custom_profile_not_encrypted(self):
@@ -178,15 +148,9 @@ class TestBackupProfiles(unittest.TestCase):
 
         self.makeapirequest.side_effect = self.profile, self.oma_values
 
-        self.count = savebackup(
-            self.directory.path, "json", self.token, self.exclude, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.token, self.exclude, "", self.append_id)
 
-        self.assertTrue(
-            Path(
-                f"{self.directory.path}/Device Configurations/test_windows10CustomConfiguration.json"
-            ).exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Device Configurations/test_windows10CustomConfiguration.json").exists())
         self.assertEqual(1, self.count["config_count"])
 
     def test_backup_non_custom_profile(self):
@@ -202,14 +166,10 @@ class TestBackupProfiles(unittest.TestCase):
             ]
         }
 
-        self.count = savebackup(
-            self.directory.path, "json", self.token, self.exclude, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.token, self.exclude, "", self.append_id)
 
         self.assertTrue(
-            Path(
-                f"{self.directory.path}/Device Configurations/test_macOSGeneralDeviceConfiguration.json"
-            ).exists()
+            Path(f"{self.directory.path}/Device Configurations/test_macOSGeneralDeviceConfiguration.json").exists()
         )
         self.assertEqual(1, self.count["config_count"])
 
@@ -238,14 +198,10 @@ class TestBackupProfiles(unittest.TestCase):
             ]
         }
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", True
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", True)
 
         self.assertTrue(
-            Path(
-                f"{self.directory.path}/Device Configurations/test_macOSGeneralDeviceConfiguration_0.json"
-            ).exists()
+            Path(f"{self.directory.path}/Device Configurations/test_macOSGeneralDeviceConfiguration__0.json").exists()
         )
 
 

--- a/tests/Backup/test_backup_remoteAssistancePartner.py
+++ b/tests/Backup/test_backup_remoteAssistancePartner.py
@@ -20,15 +20,9 @@ class TestBackupCompliancePartner(unittest.TestCase):
         self.directory.create()
         self.token = "token"
         self.append_id = False
-        self.saved_path = (
-            f"{self.directory.path}/Partner Connections/Remote Assistance/test."
-        )
+        self.saved_path = f"{self.directory.path}/Partner Connections/Remote Assistance/test."
         self.expected_data = {"onboardingStatus": "onboarded", "displayName": "test"}
-        self.remote_assistance_partner = {
-            "value": [
-                {"id": "0", "onboardingStatus": "onboarded", "displayName": "test"}
-            ]
-        }
+        self.remote_assistance_partner = {"value": [{"id": "0", "onboardingStatus": "onboarded", "displayName": "test"}]}
 
         self.patch_makeapirequest = patch(
             "src.IntuneCD.backup_remoteAssistancePartner.makeapirequest",
@@ -49,11 +43,7 @@ class TestBackupCompliancePartner(unittest.TestCase):
             data = json.dumps(yaml.safe_load(f))
             self.saved_data = json.loads(data)
 
-        self.assertTrue(
-            Path(
-                f"{self.directory.path}/Partner Connections/Remote Assistance"
-            ).exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Partner Connections/Remote Assistance").exists())
         self.assertEqual(self.expected_data, self.saved_data)
         self.assertEqual(1, self.count["config_count"])
 
@@ -65,20 +55,14 @@ class TestBackupCompliancePartner(unittest.TestCase):
         with open(self.saved_path + "json", "r") as f:
             self.saved_data = json.load(f)
 
-        self.assertTrue(
-            Path(
-                f"{self.directory.path}/Partner Connections/Remote Assistance"
-            ).exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Partner Connections/Remote Assistance").exists())
         self.assertEqual(self.expected_data, self.saved_data)
         self.assertEqual(1, self.count["config_count"])
 
     def test_onboarding_status_not_onboarded(self):
         """The count should be 0 if the onboarding status is not onboarded."""
 
-        self.makeapirequest.return_value = {
-            "value": [{"onboardingStatus": "notOnboarded"}]
-        }
+        self.makeapirequest.return_value = {"value": [{"onboardingStatus": "notOnboarded"}]}
         self.count = savebackup(self.directory.path, "json", self.token, self.append_id)
         self.assertEqual(0, self.count["config_count"])
 
@@ -94,11 +78,7 @@ class TestBackupCompliancePartner(unittest.TestCase):
 
         self.count = savebackup(self.directory.path, "json", self.token, True)
 
-        self.assertTrue(
-            Path(
-                f"{self.directory.path}/Partner Connections/Remote Assistance/test_0.json"
-            ).exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Partner Connections/Remote Assistance/test__0.json").exists())
 
 
 if __name__ == "__main__":

--- a/tests/Backup/test_backup_shellScripts.py
+++ b/tests/Backup/test_backup_shellScripts.py
@@ -25,9 +25,7 @@ class TestBackupShellScript(unittest.TestCase):
         self.exclude = []
         self.append_id = False
         self.saved_path = f"{self.directory.path}/Scripts/Shell/test."
-        self.script_content_path = (
-            f"{self.directory.path}/Scripts/Shell/Script Data/test.ps1"
-        )
+        self.script_content_path = f"{self.directory.path}/Scripts/Shell/Script Data/test.sh"
         self.expected_data = {
             "assignments": [{"target": {"groupName": "Group1"}}],
             "displayName": "test",
@@ -44,27 +42,19 @@ class TestBackupShellScript(unittest.TestCase):
             }
         ]
 
-        self.batch_assignment_patch = patch(
-            "src.IntuneCD.backup_shellScripts.batch_assignment"
-        )
+        self.batch_assignment_patch = patch("src.IntuneCD.backup_shellScripts.batch_assignment")
         self.batch_assignment = self.batch_assignment_patch.start()
         self.batch_assignment.return_value = BATCH_ASSIGNMENT
 
-        self.object_assignment_patch = patch(
-            "src.IntuneCD.backup_shellScripts.get_object_assignment"
-        )
+        self.object_assignment_patch = patch("src.IntuneCD.backup_shellScripts.get_object_assignment")
         self.object_assignment = self.object_assignment_patch.start()
         self.object_assignment.return_value = OBJECT_ASSIGNMENT
 
-        self.batch_request_patch = patch(
-            "src.IntuneCD.backup_shellScripts.batch_request"
-        )
+        self.batch_request_patch = patch("src.IntuneCD.backup_shellScripts.batch_request")
         self.batch_request = self.batch_request_patch.start()
         self.batch_request.return_value = self.batch_request_data
 
-        self.makeapirequest_patch = patch(
-            "src.IntuneCD.backup_shellScripts.makeapirequest"
-        )
+        self.makeapirequest_patch = patch("src.IntuneCD.backup_shellScripts.makeapirequest")
         self.makeapirequest = self.makeapirequest_patch.start()
         self.makeapirequest.return_value = self.script_policy_data
 
@@ -78,9 +68,7 @@ class TestBackupShellScript(unittest.TestCase):
     def test_backup_yml(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "yaml", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "yaml", self.exclude, self.token, "", self.append_id)
 
         with open(self.saved_path + "yaml", "r") as f:
             data = json.dumps(yaml.safe_load(f))
@@ -93,9 +81,7 @@ class TestBackupShellScript(unittest.TestCase):
     def test_backup_json(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", self.append_id)
 
         with open(self.saved_path + "json", "r") as f:
             self.saved_data = json.load(f)
@@ -107,9 +93,7 @@ class TestBackupShellScript(unittest.TestCase):
     def test_script_is_created(self):
         """The folder should be created and a .ps1 file should be created."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", self.append_id)
 
         self.assertTrue(f"{self.directory.path}/Scripts/Shell/Script Data")
         self.assertTrue(self.script_content_path)
@@ -119,9 +103,7 @@ class TestBackupShellScript(unittest.TestCase):
         """The count should be 0 if no data is returned."""
 
         self.batch_request.return_value = []
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", self.append_id)
 
         self.assertEqual(0, self.count["config_count"])
 
@@ -141,13 +123,10 @@ class TestBackupShellScript(unittest.TestCase):
     def test_backup_append_id(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", True
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", True)
 
-        self.assertTrue(
-            Path(f"{self.directory.path}/Scripts/Shell/test_0.json").exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Scripts/Shell/test__0.json").exists())
+        self.assertTrue(Path(f"{self.directory.path}/Scripts/Shell/Script Data/test__0.sh").exists())
 
 
 if __name__ == "__main__":

--- a/tests/Backup/test_backup_vppTokens.py
+++ b/tests/Backup/test_backup_vppTokens.py
@@ -22,9 +22,7 @@ class TestBackupVPPTokens(unittest.TestCase):
         self.append_id = False
         self.saved_path = f"{self.directory.path}/Apple VPP Tokens/test."
         self.expected_data = {"tokenName": "test", "displayName": "test"}
-        self.vpp_token = {
-            "value": [{"id": "0", "tokenName": "test", "displayName": "test"}]
-        }
+        self.vpp_token = {"value": [{"id": "0", "tokenName": "test", "displayName": "test"}]}
 
         self.patch_makeapirequest = patch(
             "src.IntuneCD.backup_vppTokens.makeapirequest",
@@ -73,9 +71,7 @@ class TestBackupVPPTokens(unittest.TestCase):
 
         self.count = savebackup(self.directory.path, "json", self.token, True)
 
-        self.assertTrue(
-            Path(f"{self.directory.path}/Apple VPP Tokens/test_0.json").exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Apple VPP Tokens/test__0.json").exists())
 
 
 if __name__ == "__main__":

--- a/tests/Backup/test_backup_windowsDriverUpdates.py
+++ b/tests/Backup/test_backup_windowsDriverUpdates.py
@@ -31,21 +31,15 @@ class TestBackupWindowsDriverUpdates(unittest.TestCase):
         }
         self.enrollment_profile = {"value": [{"displayName": "test", "id": "0"}]}
 
-        self.batch_assignment_patch = patch(
-            "src.IntuneCD.backup_windowsDriverUpdates.batch_assignment"
-        )
+        self.batch_assignment_patch = patch("src.IntuneCD.backup_windowsDriverUpdates.batch_assignment")
         self.batch_assignment = self.batch_assignment_patch.start()
         self.batch_assignment.return_value = BATCH_ASSIGNMENT
 
-        self.object_assignment_patch = patch(
-            "src.IntuneCD.backup_windowsDriverUpdates.get_object_assignment"
-        )
+        self.object_assignment_patch = patch("src.IntuneCD.backup_windowsDriverUpdates.get_object_assignment")
         self.object_assignment = self.object_assignment_patch.start()
         self.object_assignment.return_value = OBJECT_ASSIGNMENT
 
-        self.makeapirequest_patch = patch(
-            "src.IntuneCD.backup_windowsDriverUpdates.makeapirequest"
-        )
+        self.makeapirequest_patch = patch("src.IntuneCD.backup_windowsDriverUpdates.makeapirequest")
         self.makeapirequest = self.makeapirequest_patch.start()
         self.makeapirequest.return_value = self.enrollment_profile
 
@@ -59,9 +53,7 @@ class TestBackupWindowsDriverUpdates(unittest.TestCase):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
         output = "yaml"
-        count = savebackup(
-            self.directory.path, output, self.exclude, self.token, "", self.append_id
-        )
+        count = savebackup(self.directory.path, output, self.exclude, self.token, "", self.append_id)
 
         with open(self.saved_path + output, "r") as f:
             data = json.dumps(yaml.safe_load(f))
@@ -75,9 +67,7 @@ class TestBackupWindowsDriverUpdates(unittest.TestCase):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
         output = "json"
-        count = savebackup(
-            self.directory.path, output, self.exclude, self.token, "", self.append_id
-        )
+        count = savebackup(self.directory.path, output, self.exclude, self.token, "", self.append_id)
 
         with open(self.saved_path + output, "r") as f:
             saved_data = json.load(f)
@@ -90,9 +80,7 @@ class TestBackupWindowsDriverUpdates(unittest.TestCase):
         """The count should be 0 if no data is returned."""
 
         self.makeapirequest.return_value = {"value": []}
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", self.append_id)
 
         self.assertEqual(0, self.count["config_count"])
 
@@ -112,13 +100,9 @@ class TestBackupWindowsDriverUpdates(unittest.TestCase):
     def test_backup_append_id(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", True
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", True)
 
-        self.assertTrue(
-            Path(f"{self.directory.path}/Driver Updates/test_0.json").exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Driver Updates/test__0.json").exists())
 
 
 if __name__ == "__main__":

--- a/tests/Backup/test_backup_windowsEnrollmentProfile.py
+++ b/tests/Backup/test_backup_windowsEnrollmentProfile.py
@@ -31,21 +31,15 @@ class TestBackupWindowsEnrollmentProfile(unittest.TestCase):
         }
         self.enrollment_profile = {"value": [{"displayName": "test", "id": "0"}]}
 
-        self.batch_assignment_patch = patch(
-            "src.IntuneCD.backup_windowsEnrollmentProfile.batch_assignment"
-        )
+        self.batch_assignment_patch = patch("src.IntuneCD.backup_windowsEnrollmentProfile.batch_assignment")
         self.batch_assignment = self.batch_assignment_patch.start()
         self.batch_assignment.return_value = BATCH_ASSIGNMENT
 
-        self.object_assignment_patch = patch(
-            "src.IntuneCD.backup_windowsEnrollmentProfile.get_object_assignment"
-        )
+        self.object_assignment_patch = patch("src.IntuneCD.backup_windowsEnrollmentProfile.get_object_assignment")
         self.object_assignment = self.object_assignment_patch.start()
         self.object_assignment.return_value = OBJECT_ASSIGNMENT
 
-        self.makeapirequest_patch = patch(
-            "src.IntuneCD.backup_windowsEnrollmentProfile.makeapirequest"
-        )
+        self.makeapirequest_patch = patch("src.IntuneCD.backup_windowsEnrollmentProfile.makeapirequest")
         self.makeapirequest = self.makeapirequest_patch.start()
         self.makeapirequest.return_value = self.enrollment_profile
 
@@ -59,9 +53,7 @@ class TestBackupWindowsEnrollmentProfile(unittest.TestCase):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
         output = "yaml"
-        count = savebackup(
-            self.directory.path, output, self.exclude, self.token, "", self.append_id
-        )
+        count = savebackup(self.directory.path, output, self.exclude, self.token, "", self.append_id)
 
         with open(self.saved_path + output, "r") as f:
             data = json.dumps(yaml.safe_load(f))
@@ -75,9 +67,7 @@ class TestBackupWindowsEnrollmentProfile(unittest.TestCase):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
         output = "json"
-        count = savebackup(
-            self.directory.path, output, self.exclude, self.token, "", self.append_id
-        )
+        count = savebackup(self.directory.path, output, self.exclude, self.token, "", self.append_id)
 
         with open(self.saved_path + output, "r") as f:
             saved_data = json.load(f)
@@ -90,9 +80,7 @@ class TestBackupWindowsEnrollmentProfile(unittest.TestCase):
         """The count should be 0 if no data is returned."""
 
         self.makeapirequest.return_value = {"value": []}
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", self.append_id)
 
         self.assertEqual(0, self.count["config_count"])
 
@@ -112,15 +100,9 @@ class TestBackupWindowsEnrollmentProfile(unittest.TestCase):
     def test_backup_append_id(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", True
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", True)
 
-        self.assertTrue(
-            Path(
-                f"{self.directory.path}/Enrollment Profiles/Windows/test_0.json"
-            ).exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Enrollment Profiles/Windows/test__0.json").exists())
 
 
 if __name__ == "__main__":

--- a/tests/Backup/test_backup_windowsFeatureUpdates.py
+++ b/tests/Backup/test_backup_windowsFeatureUpdates.py
@@ -31,21 +31,15 @@ class TestBackupWindowsDriverUpdates(unittest.TestCase):
         }
         self.enrollment_profile = {"value": [{"displayName": "test", "id": "0"}]}
 
-        self.batch_assignment_patch = patch(
-            "src.IntuneCD.backup_windowsFeatureUpdates.batch_assignment"
-        )
+        self.batch_assignment_patch = patch("src.IntuneCD.backup_windowsFeatureUpdates.batch_assignment")
         self.batch_assignment = self.batch_assignment_patch.start()
         self.batch_assignment.return_value = BATCH_ASSIGNMENT
 
-        self.object_assignment_patch = patch(
-            "src.IntuneCD.backup_windowsFeatureUpdates.get_object_assignment"
-        )
+        self.object_assignment_patch = patch("src.IntuneCD.backup_windowsFeatureUpdates.get_object_assignment")
         self.object_assignment = self.object_assignment_patch.start()
         self.object_assignment.return_value = OBJECT_ASSIGNMENT
 
-        self.makeapirequest_patch = patch(
-            "src.IntuneCD.backup_windowsFeatureUpdates.makeapirequest"
-        )
+        self.makeapirequest_patch = patch("src.IntuneCD.backup_windowsFeatureUpdates.makeapirequest")
         self.makeapirequest = self.makeapirequest_patch.start()
         self.makeapirequest.return_value = self.enrollment_profile
 
@@ -59,9 +53,7 @@ class TestBackupWindowsDriverUpdates(unittest.TestCase):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
         output = "yaml"
-        count = savebackup(
-            self.directory.path, output, self.exclude, self.token, "", self.append_id
-        )
+        count = savebackup(self.directory.path, output, self.exclude, self.token, "", self.append_id)
 
         with open(self.saved_path + output, "r") as f:
             data = json.dumps(yaml.safe_load(f))
@@ -75,9 +67,7 @@ class TestBackupWindowsDriverUpdates(unittest.TestCase):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
         output = "json"
-        count = savebackup(
-            self.directory.path, output, self.exclude, self.token, "", self.append_id
-        )
+        count = savebackup(self.directory.path, output, self.exclude, self.token, "", self.append_id)
 
         with open(self.saved_path + output, "r") as f:
             saved_data = json.load(f)
@@ -90,9 +80,7 @@ class TestBackupWindowsDriverUpdates(unittest.TestCase):
         """The count should be 0 if no data is returned."""
 
         self.makeapirequest.return_value = {"value": []}
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", self.append_id)
 
         self.assertEqual(0, self.count["config_count"])
 
@@ -112,13 +100,9 @@ class TestBackupWindowsDriverUpdates(unittest.TestCase):
     def test_backup_append_id(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", True
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", True)
 
-        self.assertTrue(
-            Path(f"{self.directory.path}/Feature Updates/test_0.json").exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Feature Updates/test__0.json").exists())
 
 
 if __name__ == "__main__":

--- a/tests/Backup/test_backup_windowsQualityUpdates.py
+++ b/tests/Backup/test_backup_windowsQualityUpdates.py
@@ -31,21 +31,15 @@ class TestBackupWindowsDriverUpdates(unittest.TestCase):
         }
         self.enrollment_profile = {"value": [{"displayName": "test", "id": "0"}]}
 
-        self.batch_assignment_patch = patch(
-            "src.IntuneCD.backup_windowsQualityUpdates.batch_assignment"
-        )
+        self.batch_assignment_patch = patch("src.IntuneCD.backup_windowsQualityUpdates.batch_assignment")
         self.batch_assignment = self.batch_assignment_patch.start()
         self.batch_assignment.return_value = BATCH_ASSIGNMENT
 
-        self.object_assignment_patch = patch(
-            "src.IntuneCD.backup_windowsQualityUpdates.get_object_assignment"
-        )
+        self.object_assignment_patch = patch("src.IntuneCD.backup_windowsQualityUpdates.get_object_assignment")
         self.object_assignment = self.object_assignment_patch.start()
         self.object_assignment.return_value = OBJECT_ASSIGNMENT
 
-        self.makeapirequest_patch = patch(
-            "src.IntuneCD.backup_windowsQualityUpdates.makeapirequest"
-        )
+        self.makeapirequest_patch = patch("src.IntuneCD.backup_windowsQualityUpdates.makeapirequest")
         self.makeapirequest = self.makeapirequest_patch.start()
         self.makeapirequest.return_value = self.enrollment_profile
 
@@ -59,9 +53,7 @@ class TestBackupWindowsDriverUpdates(unittest.TestCase):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
         output = "yaml"
-        count = savebackup(
-            self.directory.path, output, self.exclude, self.token, "", self.append_id
-        )
+        count = savebackup(self.directory.path, output, self.exclude, self.token, "", self.append_id)
 
         with open(self.saved_path + output, "r") as f:
             data = json.dumps(yaml.safe_load(f))
@@ -75,9 +67,7 @@ class TestBackupWindowsDriverUpdates(unittest.TestCase):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
         output = "json"
-        count = savebackup(
-            self.directory.path, output, self.exclude, self.token, "", self.append_id
-        )
+        count = savebackup(self.directory.path, output, self.exclude, self.token, "", self.append_id)
 
         with open(self.saved_path + output, "r") as f:
             saved_data = json.load(f)
@@ -90,9 +80,7 @@ class TestBackupWindowsDriverUpdates(unittest.TestCase):
         """The count should be 0 if no data is returned."""
 
         self.makeapirequest.return_value = {"value": []}
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", self.append_id
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", self.append_id)
 
         self.assertEqual(0, self.count["config_count"])
 
@@ -112,13 +100,9 @@ class TestBackupWindowsDriverUpdates(unittest.TestCase):
     def test_backup_append_id(self):
         """The folder should be created, the file should have the expected contents, and the count should be 1."""
 
-        self.count = savebackup(
-            self.directory.path, "json", self.exclude, self.token, "", True
-        )
+        self.count = savebackup(self.directory.path, "json", self.exclude, self.token, "", True)
 
-        self.assertTrue(
-            Path(f"{self.directory.path}/Quality Updates/test_0.json").exists()
-        )
+        self.assertTrue(Path(f"{self.directory.path}/Quality Updates/test__0.json").exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_graph_request.py
+++ b/tests/test_graph_request.py
@@ -93,7 +93,7 @@ class TestGraphRequestGet(unittest.TestCase):
             mock_get.return_value = self.mock_resp
             makeapirequest("https://endpoint", self.token)
 
-        self.assertEqual(2, mock_get.call_count)
+        self.assertEqual(4, mock_get.call_count)
 
     def test_makeapirequest_status_503_no_q_param(self, mock_sleep, mock_get, mock_makeapirequest):
         """The request should be made twice and exception should be raised."""
@@ -102,7 +102,7 @@ class TestGraphRequestGet(unittest.TestCase):
             mock_get.return_value = self.mock_resp
             makeapirequest("https://endpoint", self.token)
 
-        self.assertEqual(2, mock_get.call_count)
+        self.assertEqual(4, mock_get.call_count)
 
     def test_makeapirequest_status_504_no_q_param(self, mock_sleep, mock_get, mock_makeapirequest):
         """The request should be made twice and exception should be raised."""
@@ -111,7 +111,7 @@ class TestGraphRequestGet(unittest.TestCase):
             mock_get.return_value = self.mock_resp
             makeapirequest("https://endpoint", self.token)
 
-        self.assertEqual(2, mock_get.call_count)
+        self.assertEqual(4, mock_get.call_count)
 
     def test_makeapirequest_with_q_param(self, mock_sleep, mock_get, mock_makeapirequest):
         """The request should be made once and the response should be returned."""


### PR DESCRIPTION
## Enhancements: 
- Additional retries on 502,503 and 504 response
- ID appended to additional files,
     - Shell script data
     - Powershell script data
     - Custom attribute data
- ID delimiter changed to "__" as Graph is using "_" in some IDs

## Bug Fixes:
- Win32 apps always added an extra "_" in the name even if a version was not configured

closes #136 
closes #137 
closes #135 