### PR TITLE
Global App Protection

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 2.0.7
+version = 2.0.8.beta1
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/src/IntuneCD/backup/Intune/backup_AppProtection.py
+++ b/src/IntuneCD/backup/Intune/backup_AppProtection.py
@@ -45,7 +45,10 @@ def savebackup(path, output, exclude, token, prefix, append_id):
 
         results["config_count"] += 1
 
-        if "assignments" not in exclude:
+        if (
+            "assignments" not in exclude
+            and profile["@odata.type"] != "#microsoft.graph.defaultManagedAppProtection"
+        ):
             assignments = get_object_assignment(profile["id"], assignment_responses)
             if assignments:
                 profile["assignments"] = assignments


### PR DESCRIPTION
Fixes a problem where App Protection could not be backed up if a global policy exists and assignments were included in the backup.

Closes #159 