### PR TITLE
2.0.9.b2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 2.0.9.beta1
+version = 2.0.9.beta2
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/src/IntuneCD/backup_intune.py
+++ b/src/IntuneCD/backup_intune.py
@@ -7,7 +7,7 @@ def backup_intune(results, path, output, exclude, token, prefix, append_id, args
     if args.activationlock:
         from .backup.Intune.backup_activationLock import savebackup
 
-        results.append(savebackup(path, output, token))
+        savebackup(path, output, token)
 
     if "AppConfigurations" not in exclude:
         from .backup.Intune.backup_appConfiguration import savebackup

--- a/src/IntuneCD/document_intune.py
+++ b/src/IntuneCD/document_intune.py
@@ -10,16 +10,6 @@ def document_intune(configpath, outpath, maxlength, split, cleanup, decode):
     This function is used to document Intune configuration.
     """
 
-    document_configs(
-        f"{configpath}/Roles",
-        outpath,
-        "Roles",
-        maxlength,
-        split,
-        cleanup,
-        decode,
-    )
-
     # Document App Configuration
     document_configs(
         f"{configpath}/App Configuration",
@@ -371,6 +361,17 @@ def document_intune(configpath, outpath, maxlength, split, cleanup, decode):
         f"{configpath}/Quality Updates",
         outpath,
         "Windows Quality Updates",
+        maxlength,
+        split,
+        cleanup,
+        decode,
+    )
+
+    # Document Roles
+    document_configs(
+        f"{configpath}/Roles",
+        outpath,
+        "Roles",
         maxlength,
         split,
         cleanup,

--- a/src/IntuneCD/run_update.py
+++ b/src/IntuneCD/run_update.py
@@ -108,6 +108,7 @@ def start():
             "DeviceManagementSettings",
             "CustomAttributes",
             "DeviceCategories",
+            "Roles",
             "entraAuthenticationFlowsPolicy",
             "entraAuthenticationMethods",
             "entraAuthorizationPolicy",

--- a/src/IntuneCD/update/Intune/update_roles.py
+++ b/src/IntuneCD/update/Intune/update_roles.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+This module is used to update all Roles in Intune.
+"""
+
+import json
+import os
+
+from deepdiff import DeepDiff
+
+from ...intunecdlib.check_file import check_file
+from ...intunecdlib.diff_summary import DiffSummary
+from ...intunecdlib.graph_request import (
+    makeapirequest,
+    makeapirequestDelete,
+    makeapirequestPatch,
+    makeapirequestPost,
+)
+from ...intunecdlib.load_file import load_file
+from ...intunecdlib.remove_keys import remove_keys
+
+# Set MS Graph endpoint
+ENDPOINT = "https://graph.microsoft.com/beta/deviceManagement/roleDefinitions"
+
+
+def update(path, token, report, remove=False):
+    """
+    This function updates all Roles in Intune if the configuration in Intune differs from the JSON/YAML file.
+
+    :param path: Path to where the backup is saved
+    :param token: Token to use for authenticating the request
+    """
+
+    diff_summary = []
+    # Set Roles path
+    configpath = path + "/" + "Roles"
+    # If App Configuration path exists, continue
+    if os.path.exists(configpath):
+        # get all Roles
+        q_param = {"$filter": "isBuiltIn eq false"}
+        mem_data = makeapirequest(ENDPOINT, token, q_param)
+
+        for filename in os.listdir(configpath):
+            file = check_file(configpath, filename)
+            if file is False:
+                continue
+            # Check which format the file is saved as then open file, load data
+            # and set query parameter
+            with open(file, encoding="utf-8") as f:
+                repo_data = load_file(filename, f)
+
+            role_value = {}
+
+            # If Filter exists, continue
+            if mem_data["value"]:
+                for val in mem_data["value"]:
+                    if repo_data["displayName"] == val["displayName"]:
+                        role_value = val
+                        mem_data["value"].remove(val)
+
+            if role_value:
+                print("-" * 90)
+                role_id = role_value["id"]
+                role_value = remove_keys(role_value)
+
+                repo_data.pop("roleAssignments", None)
+                role_value.pop("permissions", None)
+                role_value["rolePermissions"][0].pop("actions", None)
+
+                diff = DeepDiff(
+                    role_value,
+                    repo_data,
+                    ignore_order=True,
+                    exclude_paths="root['rolePermissions']",
+                ).get("values_changed", {})
+
+                actions_diff = DeepDiff(
+                    role_value["rolePermissions"][0]["resourceActions"],
+                    repo_data["rolePermissions"][0]["resourceActions"],
+                    ignore_order=True,
+                )
+
+                # If any changed values are found, push them to Intune
+                if diff or actions_diff and report is False:
+                    repo_data.pop("isBuiltInRoleDefinition", None)
+                    repo_data.pop("isBuiltIn", None)
+                    request_data = json.dumps(repo_data)
+                    makeapirequestPatch(
+                        ENDPOINT + "/" + role_id,
+                        token,
+                        q_param=None,
+                        jdata=request_data,
+                    )
+
+                diff_config = DiffSummary(
+                    data=diff,
+                    name=repo_data["displayName"],
+                    type="Role",
+                )
+
+                if actions_diff:
+                    print("Resource Actions changed, check commit history for details")
+
+                diff_summary.append(diff_config)
+
+            # If Filter does not exist, create it
+            else:
+                print("-" * 90)
+                print("Role not found, creating role: " + repo_data["displayName"])
+                if report is False:
+                    request_json = json.dumps(repo_data)
+                    post_request = makeapirequestPost(
+                        ENDPOINT,
+                        token,
+                        q_param=None,
+                        jdata=request_json,
+                    )
+                    print("Role created with id: " + post_request["id"])
+
+        # If any Roles are left in mem_data, remove them from Intune as they are not in the repo
+        if mem_data.get("value", None) is not None and remove is True:
+            for val in mem_data["value"]:
+                print("-" * 90)
+                print("Removing Role from Intune: " + val["displayName"])
+                if report is False:
+                    makeapirequestDelete(
+                        f"{ENDPOINT}/{val['id']}", token, status_code=200
+                    )
+
+    return diff_summary

--- a/src/IntuneCD/update_intune.py
+++ b/src/IntuneCD/update_intune.py
@@ -14,6 +14,7 @@ def update_intune(
     """
     Imports all the update functions and runs them
     """
+
     if "AppConfigurations" not in exclude:
         from .update.Intune.update_appConfiguration import update
 
@@ -167,3 +168,8 @@ def update_intune(
         diff_summary.append(
             update(path, token, assignment, report, create_groups, remove)
         )
+
+    if "Roles" not in exclude:
+        from .update.Intune.update_roles import update
+
+        diff_summary.append(update(path, token, report, remove))

--- a/tests/Backup/Intune/test_backup_roles.py
+++ b/tests/Backup/Intune/test_backup_roles.py
@@ -26,34 +26,54 @@ class TestBackupRoles(unittest.TestCase):
         self.expected_data = {
             "@odata.type": "#microsoft.graph.deviceAndAppManagementRoleDefinition",
             "displayName": "test",
-            "description": "test.",
-            "isBuiltInRoleDefinition": True,
-            "isBuiltIn": True,
-            "roleScopeTagIds": [],
-            "permissions": [
+            "description": "",
+            "isBuiltInRoleDefinition": False,
+            "isBuiltIn": False,
+            "roleScopeTagIds": ["0"],
+            "rolePermissions": [
                 {
-                    "actions": ["test"],
-                    "resourceActions": ["test"],
+                    "resourceActions": [
+                        {
+                            "allowedResourceActions": [
+                                "Microsoft.Intune_DeviceConfigurations_Read"
+                            ],
+                            "notAllowedResourceActions": [],
+                        }
+                    ]
                 }
             ],
             "roleAssignments": [
-                {"id": "test", "roleAssignments": {"displayName": "test", "id": "test"}}
+                {
+                    "displayName": "test",
+                    "description": "",
+                    "scopeMembers": ["admin"],
+                    "scopeType": "resourceScope",
+                    "members": ["test"],
+                }
             ],
         }
         self.role = {
             "value": [
                 {
                     "@odata.type": "#microsoft.graph.deviceAndAppManagementRoleDefinition",
-                    "id": "0",
                     "displayName": "test",
-                    "description": "test.",
-                    "isBuiltInRoleDefinition": True,
-                    "isBuiltIn": True,
-                    "roleScopeTagIds": [],
-                    "permissions": [
+                    "description": "",
+                    "id": "0",
+                    "isBuiltInRoleDefinition": False,
+                    "isBuiltIn": False,
+                    "roleScopeTagIds": ["0"],
+                    "permissions": [],
+                    "rolePermissions": [
                         {
-                            "actions": ["test"],
-                            "resourceActions": ["test"],
+                            "actions": [],
+                            "resourceActions": [
+                                {
+                                    "allowedResourceActions": [
+                                        "Microsoft.Intune_DeviceConfigurations_Read"
+                                    ],
+                                    "notAllowedResourceActions": [],
+                                }
+                            ],
                         }
                     ],
                 }
@@ -62,18 +82,26 @@ class TestBackupRoles(unittest.TestCase):
         self.assignment = {
             "value": [
                 {
-                    "id": "test",
-                    "roleAssignments": {
-                        "id": "test",
-                        "displayName": "test",
-                    },
+                    "id": "0",
+                    "displayName": "test",
+                    "description": "",
+                    "scopeMembers": ["1"],
+                    "scopeType": "resourceScope",
+                    "resourceScopes": ["222"],
+                    "members": ["111"],
                 }
             ]
         }
 
         self.patch_makeapirequest = patch(
             "src.IntuneCD.backup.Intune.backup_roles.makeapirequest",
-            side_effect=[self.role, self.assignment, self.assignment["value"][0]],
+            side_effect=[
+                self.role,
+                self.assignment,
+                self.assignment["value"][0],
+                {"displayName": "admin"},
+                {"displayName": "test"},
+            ],
         )
         self.makeapirequest = self.patch_makeapirequest.start()
 

--- a/tests/Update/Intune/test_update_roles.py
+++ b/tests/Update/Intune/test_update_roles.py
@@ -1,0 +1,171 @@
+# -*- coding: utf-8 -*-
+import unittest
+from unittest.mock import patch
+
+from testfixtures import TempDirectory
+
+from src.IntuneCD.update.Intune.update_roles import update
+
+
+class TestUpdaterole(unittest.TestCase):
+    """Test class for update_role."""
+
+    def setUp(self):
+        self.directory = TempDirectory()
+        self.directory.create()
+        self.directory.makedir("Roles")
+        self.directory.write("Roles/test.json", '{"test": "test"}', encoding="utf-8")
+        self.directory.write("Roles/test.txt", '{"test": "test"}', encoding="utf-8")
+        self.token = "token"
+        self.mem_data = {
+            "value": [
+                {
+                    "@odata.type": "#microsoft.graph.deviceAndAppManagementRoleDefinition",
+                    "displayName": "test",
+                    "description": "",
+                    "id": "0",
+                    "isBuiltInRoleDefinition": False,
+                    "isBuiltIn": False,
+                    "roleScopeTagIds": ["0"],
+                    "permissions": [],
+                    "rolePermissions": [
+                        {
+                            "actions": [],
+                            "resourceActions": [
+                                {
+                                    "allowedResourceActions": [
+                                        "Microsoft.Intune_DeviceConfigurations_Read"
+                                    ],
+                                    "notAllowedResourceActions": [],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ]
+        }
+        self.repo_data = {
+            "@odata.type": "#microsoft.graph.deviceAndAppManagementRoleDefinition",
+            "displayName": "test",
+            "description": "",
+            "isBuiltInRoleDefinition": False,
+            "isBuiltIn": False,
+            "roleScopeTagIds": ["0"],
+            "rolePermissions": [
+                {
+                    "resourceActions": [
+                        {
+                            "allowedResourceActions": [
+                                "Microsoft.Intune_DeviceConfigurations_Read"
+                            ],
+                            "notAllowedResourceActions": [],
+                        }
+                    ]
+                }
+            ],
+            "roleAssignments": [
+                {
+                    "displayName": "test",
+                    "description": "",
+                    "scopeMembers": ["admin"],
+                    "scopeType": "resourceScope",
+                    "members": ["test"],
+                }
+            ],
+        }
+
+        self.makeapirequest_patch = patch(
+            "src.IntuneCD.update.Intune.update_roles.makeapirequest"
+        )
+        self.makeapirequest = self.makeapirequest_patch.start()
+        self.makeapirequest.return_value = self.mem_data
+
+        self.load_file_patch = patch(
+            "src.IntuneCD.update.Intune.update_roles.load_file"
+        )
+        self.load_file = self.load_file_patch.start()
+        self.load_file.return_value = self.repo_data
+
+        self.makeapirequestPatch_patch = patch(
+            "src.IntuneCD.update.Intune.update_roles.makeapirequestPatch"
+        )
+        self.makeapirequestPatch = self.makeapirequestPatch_patch.start()
+
+        self.makeapirequestPost_patch = patch(
+            "src.IntuneCD.update.Intune.update_roles.makeapirequestPost"
+        )
+        self.makeapirequestPost = self.makeapirequestPost_patch.start()
+        self.makeapirequestPost.return_value = {"id": "0"}
+
+        self.makeapirequestDelete_patch = patch(
+            "src.IntuneCD.update.Intune.update_roles.makeapirequestDelete"
+        )
+        self.makeapirequestDelete = self.makeapirequestDelete_patch.start()
+
+    def tearDown(self):
+        self.directory.cleanup()
+        self.makeapirequest_patch.stop()
+        self.load_file_patch.stop()
+        self.makeapirequestPatch_patch.stop()
+        self.makeapirequestPost_patch.stop()
+        self.makeapirequestDelete_patch.stop()
+
+    def test_update_with_diffs(self):
+        """The count should be 1 and makeapirequestPatch should be called."""
+        self.repo_data["description"] = "test"
+
+        self.count = update(self.directory.path, self.token, report=False, remove=False)
+
+        self.assertEqual(self.count[0].count, 1)
+        self.assertEqual(self.makeapirequestPatch.call_count, 1)
+        self.assertEqual(self.makeapirequestPatch.call_count, 1)
+
+    def test_update_with_multiple_diffs(self):
+        """The count should be 1 and makeapirequestPatch should be called."""
+
+        self.repo_data["description"] = "test"
+        self.repo_data["rolePermissions"][0]["resourceActions"][0][
+            "allowedResourceActions"
+        ].append("test")
+
+        self.count = update(self.directory.path, self.token, report=False, remove=False)
+
+        self.assertEqual(self.count[0].count, 1)
+        self.assertEqual(self.makeapirequestPatch.call_count, 1)
+        self.assertEqual(self.makeapirequestPatch.call_count, 1)
+
+    def test_update_with_no_diffs(self):
+        """The count should be 0 and makeapirequestPatch should not be called."""
+
+        self.count = update(self.directory.path, self.token, report=False, remove=False)
+
+        self.assertEqual(self.count[0].count, 0)
+        self.assertEqual(self.makeapirequestPatch.call_count, 0)
+        self.assertEqual(self.makeapirequestPatch.call_count, 0)
+
+    def test_update_config_not_found(self):
+        """The count should be 0 and makeapirequestPost should be called."""
+
+        self.mem_data["value"][0]["displayName"] = "test1"
+        self.count = update(self.directory.path, self.token, report=False, remove=False)
+
+        self.assertEqual(self.count, [])
+        self.assertEqual(self.makeapirequestPost.call_count, 1)
+
+    def test_update_config_not_found_remove(self):
+        """The count should be 0 and makeapirequestPost should be called."""
+
+        self.mem_data["value"].append(
+            {
+                "displayName": "test2",
+                "id": "0",
+            }
+        )
+        self.count = update(self.directory.path, self.token, report=False, remove=True)
+
+        # self.assertEqual(self.count, [])
+        self.assertEqual(self.makeapirequestDelete.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Group IDs in roles backup is now converting to group names
- Only custom roles are now backed up
- Added updating/removal of roles
- Role exports are cleaned up a bit to get rid of unnecessary properties