### PR TITLE
v2.1.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 2.1.0
+version = 2.1.1
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/src/IntuneCD/backup/Intune/backup_managedGPlay.py
+++ b/src/IntuneCD/backup/Intune/backup_managedGPlay.py
@@ -15,7 +15,7 @@ ENDPOINT = "https://graph.microsoft.com/beta/deviceManagement/androidManagedStor
 
 
 # Get Managed Google Play information and save in specified path
-def savebackup(path, output, token, append_id):
+def savebackup(path, output, exclude, token, append_id):
     """
     Saves Managed Google Play information in Intune to a JSON or YAML file.
 
@@ -38,6 +38,9 @@ def savebackup(path, output, token, append_id):
         fname = clean_filename(data["ownerUserPrincipalName"])
         if append_id:
             fname = f"{fname}__{graph_id}"
+
+        if data.get("lastAppSyncDateTime") and "GPlaySyncTime" in exclude:
+            data.pop("lastAppSyncDateTime")
         # Save Managed Google Play as JSON or YAML depending on configured
         # value in "-o"
         save_output(output, configpath, fname, data)

--- a/src/IntuneCD/backup/Intune/backup_roles.py
+++ b/src/IntuneCD/backup/Intune/backup_roles.py
@@ -43,8 +43,7 @@ def savebackup(path, output, exclude, token, append_id):
 
             if group_name:
                 group_name = group_name["displayName"]
-
-            groups.append(group_name)
+                groups.append(group_name)
 
         return groups
 

--- a/src/IntuneCD/backup_intune.py
+++ b/src/IntuneCD/backup_intune.py
@@ -101,7 +101,7 @@ def backup_intune(results, path, output, exclude, token, prefix, append_id, args
     if "ManagedGooglePlay" not in exclude:
         from .backup.Intune.backup_managedGPlay import savebackup
 
-        results.append(savebackup(path, output, token, append_id))
+        results.append(savebackup(path, output, exclude, token, append_id))
 
     if "Intents" not in exclude:
         from .backup.Intune.backup_managementIntents import savebackup

--- a/src/IntuneCD/run_backup.py
+++ b/src/IntuneCD/run_backup.py
@@ -137,6 +137,7 @@ def start():
             "Roles",
             "ScopeTags",
             "VPPusedLicenseCount",
+            "GPlaySyncTime",
         ],
         nargs="+",
     )


### PR DESCRIPTION
### New Features
- Option to exclude Managed Google Play last sync time by adding `-e GPlaySyncTime`. closes #168 

### Fixes
- If an assigned group on a role is removed from Entra, the group would be added as `null` in the backup causing the documentation to fail. This update removes null groups from the backup.