### PR TITLE
v2.1.2

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,5 +9,6 @@ ignore:
   - "src/IntuneCD/document_entra.py"
   - "src/IntuneCD/run_documentation.py"
   - "src/IntuneCD/intunecdlib/get_accesstoken.py"
+  - "src/IntuneCD/intunecdlib/logger.py"
   - "src/IntuneCD/backup/Intune/backup_autopilotDevices.py"
   - "src/IntuneCD/backup/Intune/backup_activationLock.py"

--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@
                         </div>
                     </div>
                     <div class="col-xl-3 mb-4">
-                        <h2 class="mb-4">Follow on Twitter!</h2>
+                        <h2 class="mb-4">Follow on X!</h2>
                         <div class="col-auto">
                             <a class="btn btn-primary btn-lg" href="https://twitter.com/intunecd">Follow</a>
                         </div>
@@ -182,7 +182,7 @@
                             <li class="list-inline-item">⋅</li>
                             <li class="list-inline-item"><a href="#!" class="text-primary">Contact</a></li>
                         </ul>--->
-                        <p class="text-muted small mb-4 mb-lg-0">&copy; IntuneCD 2023. All Rights Reserved.</p>
+                        <p class="text-muted small mb-4 mb-lg-0">&copy; IntuneCD 2024. All Rights Reserved.</p>
                     </div>
                     <div class="col-lg-6 h-100 text-center text-lg-end my-auto">
                         <ul class="list-inline mb-0">

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 2.1.1
+version = 2.1.2.beta1
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 2.1.2.beta3
+version = 2.1.2
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 2.1.2.beta1
+version = 2.1.2.beta2
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 2.1.2.beta2
+version = 2.1.2.beta3
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/src/IntuneCD/backup/Intune/backup_compliancePartner.py
+++ b/src/IntuneCD/backup/Intune/backup_compliancePartner.py
@@ -17,7 +17,7 @@ ENDPOINT = (
 
 
 # Get all Compliance Partners and save them in specified path
-def savebackup(path, output, token, append_id):
+def savebackup(path, output, exclude, token, append_id):
     """
     Saves all Compliance Partners in Intune to a JSON or YAML file.
 
@@ -44,6 +44,12 @@ def savebackup(path, output, token, append_id):
         fname = clean_filename(partner["displayName"])
         if append_id:
             fname = f"{fname}__{graph_id}"
+
+        if (
+            partner.get("lastHeartbeatDateTime")
+            and "CompliancePartnerHeartbeat" in exclude
+        ):
+            partner.pop("lastHeartbeatDateTime", None)
         # Save Compliance policy as JSON or YAML depending on configured
         # value in "-o"
         save_output(output, configpath, fname, partner)

--- a/src/IntuneCD/backup/Intune/backup_profiles.py
+++ b/src/IntuneCD/backup/Intune/backup_profiles.py
@@ -112,6 +112,8 @@ def savebackup(path, output, exclude, token, prefix, append_id, ignore_omasettin
                         )
                         decoded_oma["value"] = oma_value
                         omas.append(decoded_oma)
+                    else:
+                        omas.append(setting)
 
             else:
                 omas = profile["omaSettings"]

--- a/src/IntuneCD/backup_intune.py
+++ b/src/IntuneCD/backup_intune.py
@@ -111,7 +111,7 @@ def backup_intune(results, path, output, exclude, token, prefix, append_id, args
     if "CompliancePartner" not in exclude:
         from .backup.Intune.backup_compliancePartner import savebackup
 
-        results.append(savebackup(path, output, token, append_id))
+        results.append(savebackup(path, output, exclude, token, append_id))
 
     if "ManagementPartner" not in exclude:
         from .backup.Intune.backup_managementPartner import savebackup

--- a/src/IntuneCD/intunecdlib/get_accesstoken.py
+++ b/src/IntuneCD/intunecdlib/get_accesstoken.py
@@ -91,7 +91,7 @@ def obtain_accesstoken_cert(TENANT_NAME, CLIENT_ID, THUMBPRINT, KEY_FILE):
     return token
 
 
-def obtain_accesstoken_interactive(TENANT_NAME, CLIENT_ID):
+def obtain_accesstoken_interactive(TENANT_NAME, CLIENT_ID, scopes):
     """
     This function is used to get an access token to MS Graph interactivly.
 
@@ -108,17 +108,6 @@ def obtain_accesstoken_interactive(TENANT_NAME, CLIENT_ID):
     )
 
     token = None
-
-    # Set the requited scopes
-    scopes = [
-        "DeviceManagementApps.ReadWrite.All",
-        "DeviceManagementConfiguration.ReadWrite.All",
-        "DeviceManagementManagedDevices.Read.All",
-        "DeviceManagementServiceConfig.ReadWrite.All",
-        "Group.Read.All",
-        "Policy.ReadWrite.ConditionalAccess",
-        "Policy.Read.All",
-    ]
 
     try:
         # Get the token interactively

--- a/src/IntuneCD/intunecdlib/get_authparams.py
+++ b/src/IntuneCD/intunecdlib/get_authparams.py
@@ -15,7 +15,7 @@ from .get_accesstoken import (
 )
 
 
-def getAuth(mode, localauth, certauth, interactiveauth, entra, tenant):
+def getAuth(mode, localauth, certauth, interactiveauth, scopes, entra, tenant):
     """
     This function authenticates to MS Graph and returns the access token.
 
@@ -42,7 +42,7 @@ def getAuth(mode, localauth, certauth, interactiveauth, entra, tenant):
         if not all([TENANT_NAME, CLIENT_ID]):
             raise ValueError("One or more os.environ variables not set")
 
-        return obtain_accesstoken_interactive(TENANT_NAME, CLIENT_ID)
+        return obtain_accesstoken_interactive(TENANT_NAME, CLIENT_ID, scopes)
 
     if mode:
         if mode == "devtoprod":

--- a/src/IntuneCD/intunecdlib/graph_batch.py
+++ b/src/IntuneCD/intunecdlib/graph_batch.py
@@ -70,95 +70,175 @@ def handle_responses(
     return responses, retry_pool, wait_time
 
 
-def batch_request(data, url, extra_url, token, method="GET") -> list:
-    """Batch request to the Graph API.
+def create_batch_list(data, batch_count) -> list:
+    """Create a list of batches from the data.
 
     Args:
-        data (list): List of IDs
+        data (list): List of objects
+        batch_count (int): Number of objects to include in each batch
+
+    Returns:
+        list: List of batches
+    """
+    return [data[i : i + batch_count] for i in range(0, len(data), batch_count)]
+
+
+def process_batch(
+    batch,
+    batch_id,
+    method,
+    url,
+    extra_url,
+    token,
+    initial_request_data,
+    responses,
+    retry_pool,
+) -> tuple:
+    """Process the batch request.
+
+    Args:
+        batch (list): List of objects
+        batch_id (str): ID for the batch request
+        method (str): HTTP method to use
         url (str): MS graph endpoint for the object
         extra_url (str): Used if anything extra is needed for the url such as /assignments or ?$filter
         token (str): OAuth token used for authentication
-        method (str, optional): HTTP method to use. Defaults to "GET".
+        initial_request_data (list): List of initial requests
+        responses (list): List of responses from the batch request
+        retry_pool (list): List of failed requests
+
+    Returns:
+        tuple: Tuple containing the batch ID, responses, retry pool and wait time
+    """
+    query_data, batch_id = create_batch_request(batch, batch_id, method, url, extra_url)
+    json_data = json.dumps(query_data)
+    request = makeapirequestPost(
+        "https://graph.microsoft.com/beta/$batch", token, jdata=json_data
+    )
+    request_data = sorted(request["responses"], key=lambda item: item.get("id"))
+    initial_request_data += query_data["requests"]
+    responses, retry_pool, wait_time = handle_responses(
+        initial_request_data, request_data, responses, retry_pool
+    )
+    return batch_id, responses, retry_pool, wait_time
+
+
+def retry_failed_requests(
+    retry_pool,
+    wait_time,
+    max_retries,
+    max_wait_time,
+    token,
+    initial_request_data,
+    responses,
+    batch_count,
+) -> tuple:
+    """Retry failed requests.
+
+    Args:
+        retry_pool (list): List of failed requests
+        wait_time (int): Time to wait before retrying
+        max_retries (int): Maximum number of retries
+        max_wait_time (int): Maximum time to wait before retrying
+        token (str): OAuth token used for authentication
+        initial_request_data (list): List of initial requests
+        responses (list): List of responses from the batch request
+        batch_count (int): Number of objects to include in each batch
 
     Returns:
         list: List of responses from the batch request
     """
-    responses = []  # list of responses
-    batch_id = 1  # batch id for the request
-    batch_count = 20  # max number of requests in a batch
-    retry_pool = []  # list of failed requests
-    wait_time = 0  # wait time for the next request if Retry-After is in the headers
-    batch_list = [data[i : i + batch_count] for i in range(0, len(data), batch_count)]
-    initial_request_data = []  # list of initial requests
-    failed_retry_requests = []  # list of failed requests after retries
-
-    for batch in batch_list:
-        query_data, batch_id = create_batch_request(
-            batch, batch_id, method, url, extra_url
-        )
-        json_data = json.dumps(query_data)
-        request = makeapirequestPost(
-            "https://graph.microsoft.com/beta/$batch", token, jdata=json_data
-        )
-        request_data = sorted(request["responses"], key=lambda item: item.get("id"))
-        initial_request_data += query_data["requests"]
-        responses, retry_pool, wait_time = handle_responses(
-            initial_request_data, request_data, responses, retry_pool
-        )
-
-    max_retries = 5  # max number of retries
-    retry_count = 0  # current retry count
-
-    # If we have a retry pool, retry the failed requests
-    if retry_pool:
-        while retry_count < max_retries and retry_pool:
-            log(
-                "batch_request",
-                f"Retrying failed requests, retry pool count: {str(len(retry_pool))}",
-            )
-            # If we have a wait time in the headers, sleep for that time
-            if wait_time > 0:
-                time.sleep(wait_time)
-            # Else, sleep for 20 seconds
-            else:
-                log(
-                    "batch_request",
-                    "No wait time in headers, sleeping for 20 seconds...",
-                )
-                time.sleep(20)
-            # Split the retry pool into batches
-            batch_list = [
-                retry_pool[i : i + batch_count]
-                for i in range(0, len(retry_pool), batch_count)
-            ]
-            # Retry each batch
-            for batch in batch_list:
-                batch_data = {"requests": list(batch)}
-                json_data = json.dumps(batch_data)
-                request = makeapirequestPost(
-                    "https://graph.microsoft.com/beta/$batch", token, jdata=json_data
-                )
-                request_data = sorted(
-                    request["responses"], key=lambda item: item.get("id")
-                )
-                responses, retry_pool, _ = handle_responses(
-                    initial_request_data, request_data, responses, retry_pool
-                )
-                # If we still have a retry pool, get the failed requests
-                failed_retry_requests = [
-                    r for r in request["responses"] if r["status"] != 200
-                ]
-
-            retry_count += 1
-            log("batch_request", f"Retry count: {str(retry_count)}")
-
-            # If we still have a retry pool but the max retries has been reached, exit the loop
-            if retry_pool and retry_count == max_retries:
-                break
-
+    retry_count = 0
+    failed_retry_requests = []
+    while retry_count < max_retries and retry_pool:
         log(
-            "batch_request",
-            f"Failed requests after {str(retry_count)} retries: {str(len(failed_retry_requests))}",
+            "retry_failed_requests",
+            f"Retrying failed requests, retry pool count: {str(len(retry_pool))}",
+        )
+        if wait_time > 0:
+            log("retry_failed_requests", f"Sleeping for {str(wait_time)} seconds...")
+            time.sleep(wait_time)
+            wait_time = min(wait_time * 2, max_wait_time)
+        else:
+            log(
+                "retry_failed_requests",
+                "No wait time in headers, sleeping for 20 seconds...",
+            )
+            time.sleep(20)
+        batch_list = [
+            retry_pool[i : i + batch_count]
+            for i in range(0, len(retry_pool), batch_count)
+        ]
+        for batch in batch_list:
+            batch_data = {"requests": list(batch)}
+            json_data = json.dumps(batch_data)
+            request = makeapirequestPost(
+                "https://graph.microsoft.com/beta/$batch", token, jdata=json_data
+            )
+            request_data = sorted(request["responses"], key=lambda item: item.get("id"))
+            responses, retry_pool, _ = handle_responses(
+                initial_request_data, request_data, responses, retry_pool
+            )
+            failed_retry_requests = [
+                r for r in request["responses"] if r["status"] != 200
+            ]
+        retry_count += 1
+        log("retry_failed_requests", f"Retry count: {str(retry_count)}")
+        if retry_pool and retry_count == max_retries:
+            break
+    log(
+        "retry_failed_requests",
+        f"Failed requests after {str(retry_count)} retries: {str(len(failed_retry_requests))}",
+    )
+    return responses
+
+
+def batch_request(data, url, extra_url, token, method="GET") -> list:
+    """Batch request to the Graph API.
+
+    Args:
+        data (list): List of objects
+        url (str): MS graph endpoint for the object
+        extra_url (str): Used if anything extra is needed for the url such as /assignments or ?$filter
+        token (str): OAuth token used for authentication
+        method (str): HTTP method to use
+
+    Returns:
+        list: List of responses from the batch request
+    """
+    responses = []
+    batch_id = 1
+    batch_count = 20
+    retry_pool = []
+    wait_time = 0
+    initial_request_data = []
+
+    batch_list = create_batch_list(data, batch_count)
+    for batch in batch_list:
+        batch_id, responses, retry_pool, wait_time = process_batch(
+            batch,
+            batch_id,
+            method,
+            url,
+            extra_url,
+            token,
+            initial_request_data,
+            responses,
+            retry_pool,
+        )
+
+    max_retries = 10
+    max_wait_time = 60
+    if retry_pool:
+        responses = retry_failed_requests(
+            retry_pool,
+            wait_time,
+            max_retries,
+            max_wait_time,
+            token,
+            initial_request_data,
+            responses,
+            batch_count,
         )
 
     return responses

--- a/src/IntuneCD/intunecdlib/logger.py
+++ b/src/IntuneCD/intunecdlib/logger.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+This module is used to log messages if verbose is set to True.
+"""
+
+import os
+import time
+
+verbose = os.getenv("VERBOSE")
+
+
+def log(function, msg):
+    """Prints a message to the console if the VERBOSE environment variable is set to True.
+
+    Args:
+        function (str): The name of the function that is calling the log function.
+        msg (str): The message to print to the console.
+    """
+    if verbose:
+        msg = f"[{time.asctime()}] - [{function}] - {msg}"
+        print(msg)

--- a/src/IntuneCD/run_backup.py
+++ b/src/IntuneCD/run_backup.py
@@ -182,6 +182,11 @@ def start():
         help="When set, backs up Activation Lock Bypass Codes",
         action="store_true",
     )
+    parser.add_argument(
+        "--scopes",
+        help="The scopes to use when obtaining an access token interactively separated by space. Only used when using interactive auth. Default is: DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementManagedDevices.Read.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementRBAC.ReadWrite.All, Group.Read.All, Policy.ReadWrite.ConditionalAccess, Policy.Read.All",
+        nargs="+",
+    )
 
     args = parser.parse_args()
 
@@ -202,11 +207,24 @@ def start():
     else:
         args.mode = selected_mode(args.mode)
 
+    if not args.scopes:
+        args.scopes = [
+            "DeviceManagementApps.ReadWrite.All",
+            "DeviceManagementConfiguration.ReadWrite.All",
+            "DeviceManagementManagedDevices.Read.All",
+            "DeviceManagementServiceConfig.ReadWrite.All",
+            "DeviceManagementRBAC.ReadWrite.All",
+            "Group.Read.All",
+            "Policy.ReadWrite.ConditionalAccess",
+            "Policy.Read.All",
+        ]
+
     token = getAuth(
         args.mode,
         args.localauth,
         args.certauth,
         args.interactiveauth,
+        args.scopes,
         args.entrabackup,
         tenant="DEV",
     )

--- a/src/IntuneCD/run_backup.py
+++ b/src/IntuneCD/run_backup.py
@@ -138,6 +138,7 @@ def start():
             "ScopeTags",
             "VPPusedLicenseCount",
             "GPlaySyncTime",
+            "CompliancePartnerHeartbeat",
         ],
         nargs="+",
     )

--- a/src/IntuneCD/run_backup.py
+++ b/src/IntuneCD/run_backup.py
@@ -187,8 +187,14 @@ def start():
         help="The scopes to use when obtaining an access token interactively separated by space. Only used when using interactive auth. Default is: DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementManagedDevices.Read.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementRBAC.ReadWrite.All, Group.Read.All, Policy.ReadWrite.ConditionalAccess, Policy.Read.All",
         nargs="+",
     )
+    parser.add_argument(
+        "-v", "--verbose", help="Prints verbose output", action="store_true"
+    )
 
     args = parser.parse_args()
+
+    if args.verbose:
+        os.environ["VERBOSE"] = "True"
 
     def devtoprod():
         return "devtoprod"
@@ -301,6 +307,9 @@ def start():
 
     else:
         print("Please enter a valid output format, json or yaml")
+
+    if "VERBOSE" in os.environ:
+        del os.environ["VERBOSE"]
 
 
 if __name__ == "__main__":

--- a/src/IntuneCD/run_update.py
+++ b/src/IntuneCD/run_update.py
@@ -163,8 +163,14 @@ def start():
         help="The scopes to use when obtaining an access token interactively separated by space. Only used when using interactive auth. Default is: DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementManagedDevices.Read.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementRBAC.ReadWrite.All, Group.Read.All, Policy.ReadWrite.ConditionalAccess, Policy.Read.All",
         nargs="+",
     )
+    parser.add_argument(
+        "-v", "--verbose", help="Prints verbose output", action="store_true"
+    )
 
     args = parser.parse_args()
+
+    if args.verbose:
+        os.environ["VERBOSE"] = "True"
 
     def devtoprod():
         return "devtoprod"
@@ -308,6 +314,9 @@ def start():
                 args.create_groups,
                 args.remove,
             )
+
+    if "VERBOSE" in os.environ:
+        del os.environ["VERBOSE"]
 
 
 if __name__ == "__main__":

--- a/src/IntuneCD/run_update.py
+++ b/src/IntuneCD/run_update.py
@@ -158,6 +158,11 @@ def start():
         help="When this parameter is set, the script will also update Entra configurations",
         action="store_true",
     )
+    parser.add_argument(
+        "--scopes",
+        help="The scopes to use when obtaining an access token interactively separated by space. Only used when using interactive auth. Default is: DeviceManagementApps.ReadWrite.All, DeviceManagementConfiguration.ReadWrite.All, DeviceManagementManagedDevices.Read.All, DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementRBAC.ReadWrite.All, Group.Read.All, Policy.ReadWrite.ConditionalAccess, Policy.Read.All",
+        nargs="+",
+    )
 
     args = parser.parse_args()
 
@@ -178,11 +183,24 @@ def start():
     else:
         args.mode = selected_mode(args.mode)
 
+    if not args.scopes:
+        args.scopes = [
+            "DeviceManagementApps.ReadWrite.All",
+            "DeviceManagementConfiguration.ReadWrite.All",
+            "DeviceManagementManagedDevices.Read.All",
+            "DeviceManagementServiceConfig.ReadWrite.All",
+            "DeviceManagementRBAC.ReadWrite.All",
+            "Group.Read.All",
+            "Policy.ReadWrite.ConditionalAccess",
+            "Policy.Read.All",
+        ]
+
     token = getAuth(
         args.mode,
         args.localauth,
         args.certauth,
         args.interactiveauth,
+        args.scopes,
         args.entraupdate,
         tenant="PROD",
     )

--- a/src/IntuneCD/update/Intune/update_appleEnrollmentProfile.py
+++ b/src/IntuneCD/update/Intune/update_appleEnrollmentProfile.py
@@ -70,8 +70,14 @@ def update(path, token, report):
                         profile_data["value"][0], repo_data, ignore_order=True
                     ).get("values_changed", {})
 
+                    skip_diff = DeepDiff(
+                        profile_data["value"][0]["enabledSkipKeys"],
+                        repo_data["enabledSkipKeys"],
+                        ignore_order=True,
+                    )
+
                     # If any changed values are found, push them to Intune
-                    if diff and report is False:
+                    if diff or skip_diff and report is False:
                         request_data = json.dumps(repo_data)
                         q_param = None
                         makeapirequestPatch(

--- a/tests/Update/Intune/test_update_appleEnrollmentProfile.py
+++ b/tests/Update/Intune/test_update_appleEnrollmentProfile.py
@@ -32,6 +32,7 @@ class TestUpdateAppleEnrollmentProfile(unittest.TestCase):
                     "id": "0",
                     "displayName": "test",
                     "testvalue": "test",
+                    "enabledSkipKeys": ["test"],
                 }
             ]
         }
@@ -40,6 +41,7 @@ class TestUpdateAppleEnrollmentProfile(unittest.TestCase):
             "id": "0",
             "displayName": "test",
             "testvalue": "test1",
+            "enabledSkipKeys": ["test"],
         }
 
         self.makeapirequest_patch = patch(
@@ -79,10 +81,11 @@ class TestUpdateAppleEnrollmentProfile(unittest.TestCase):
         self.repo_data["testvalue2"] = "test2"
         self.mem_data["value"][0]["testvalue"] = "test"
         self.mem_data["value"][0]["testvalue2"] = "test1"
+        self.mem_data["value"][0]["enabledSkipKeys"] = ["test1"]
 
         self.count = update(self.directory.path, self.token, report=False)
 
-        self.assertEqual(self.count[0].count, 2)
+        self.assertEqual(self.count[0].count, 3)
         self.assertEqual(self.makeapirequestPatch.call_count, 1)
 
     def test_update_with_no_diffs(self):

--- a/tests/test_get_authparams.py
+++ b/tests/test_get_authparams.py
@@ -69,6 +69,7 @@ class TestGetAuth(unittest.TestCase):
                 localauth=None,
                 certauth=None,
                 interactiveauth=None,
+                scopes=[],
                 entra=False,
                 tenant="DEV",
             )
@@ -89,6 +90,7 @@ class TestGetAuth(unittest.TestCase):
                 localauth=None,
                 certauth=None,
                 interactiveauth=None,
+                scopes=[],
                 entra=False,
                 tenant="PROD",
             )
@@ -101,6 +103,7 @@ class TestGetAuth(unittest.TestCase):
             localauth=self.auth_dev_json,
             certauth=None,
             interactiveauth=None,
+            scopes=[],
             entra=False,
             tenant="DEV",
         )
@@ -113,6 +116,7 @@ class TestGetAuth(unittest.TestCase):
             localauth=self.auth_prod_json,
             certauth=None,
             interactiveauth=None,
+            scopes=[],
             entra=False,
             tenant="PROD",
         )
@@ -129,6 +133,7 @@ class TestGetAuth(unittest.TestCase):
                 localauth=None,
                 certauth=None,
                 interactiveauth=None,
+                scopes=[],
                 entra=False,
                 tenant=None,
             )
@@ -141,6 +146,7 @@ class TestGetAuth(unittest.TestCase):
             localauth=self.auth_json,
             certauth=None,
             interactiveauth=None,
+            scopes=[],
             entra=False,
             tenant=None,
         )
@@ -157,6 +163,7 @@ class TestGetAuth(unittest.TestCase):
                     localauth=None,
                     certauth=None,
                     interactiveauth=None,
+                    scopes=[],
                     entra=False,
                     tenant="DEV",
                 )
@@ -172,6 +179,7 @@ class TestGetAuth(unittest.TestCase):
                     localauth=None,
                     certauth=None,
                     interactiveauth=None,
+                    scopes=[],
                     entra=False,
                     tenant="PROD",
                 )
@@ -185,6 +193,7 @@ class TestGetAuth(unittest.TestCase):
                     localauth=None,
                     certauth=None,
                     interactiveauth=None,
+                    scopes=[],
                     entra=False,
                     tenant=None,
                 )
@@ -205,6 +214,7 @@ class TestGetAuth(unittest.TestCase):
                 localauth=None,
                 certauth=True,
                 interactiveauth=None,
+                scopes=[],
                 tenant=None,
                 entra=False,
             )
@@ -222,6 +232,7 @@ class TestGetAuth(unittest.TestCase):
                     localauth=None,
                     certauth=True,
                     interactiveauth=None,
+                    scopes=[],
                     entra=False,
                     tenant=None,
                 )
@@ -242,6 +253,7 @@ class TestGetAuth(unittest.TestCase):
                 localauth=None,
                 certauth=None,
                 interactiveauth=True,
+                scopes=[],
                 tenant=None,
                 entra=False,
             )
@@ -259,6 +271,7 @@ class TestGetAuth(unittest.TestCase):
                     localauth=None,
                     certauth=None,
                     interactiveauth=True,
+                    scopes=[],
                     entra=False,
                     tenant=None,
                 )


### PR DESCRIPTION
## New Features
- Added an option to override scopes when running authentication in interactive mode. Instead of using all required scopes for IntuneCD to target all payloads, you can now specify which scopes you want to have. When doing so, payloads not in a scope added must be excluded with `-e`. To override default scopes, use the new `--scopes` argument, for example `--scopes DeviceManagementApps.ReadWrite.All DeviceManagementConfiguration.ReadWrite.All`.
- Exclusion of Compliance Partner heartbeat: `-e CompliancePartnerHeartbeat`.
- New argument for `IntuneCD-startbackup` and `IntuneCD-startupdate`, added `-v` to allow for verbose logging. For now, only the `retry_failed_requests` function is using it.

## Fixes
- Non encrypted OMAs on custom Windows profiles were not included in the backup when running without `--ignore-omasettings`.
- Setup Assistant screens were not updated when running an update.

## Other updates
- Additional tweaks to batch request retries, max retry count is increased to 10 and an exponential backoff has been implemented. If `Retry-After` is included in the headers, the wait time will be multiplied on each iteration until the `max_wait_time` is reached which is 60 seconds. if a `Retry-After` is not included in the headers a 20 second wait is used by default to lower the risk of being throttled again.

closes #172 