### PR TITLE
v2.3.1

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         os: [macos-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 2.3.0.rc2
+version = 2.3.0
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 2.3.1.beta1
+version = 2.3.1
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/src/IntuneCD/intunecdlib/documentation_functions.py
+++ b/src/IntuneCD/intunecdlib/documentation_functions.py
@@ -510,7 +510,10 @@ def get_md_files(configpath):
             configpathname = configpath.split(slash)[-1]
             filepath = filepath[filepath.index(configpathname) :]
             filepath = "/".join(filepath[1:])
-
-            md_files.append(f"./{filepath}")
+            ignore_files = ["README", "index", "prod-as-built"]
+            if filepath.rsplit("/", maxsplit=1)[-1] not in ignore_files:
+                md_files.append(f"./{filepath}")
+    # Sort the list alphabetically by file name without extension, case-insensitive
+    md_files.sort(key=lambda f: os.path.splitext(os.path.basename(f))[0].lower())
 
     return md_files


### PR DESCRIPTION
## Fixes
- Audit data was not included for Applications and Management Intents as the path was incorrect when running `git add` during audit data processing. #192 

## Improvements
- Improvements to verbose output when `git commit` fails during audit processing.