### PR TITLE
v2.3.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 2.3.1
+version = 2.3.2.beta1
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 2.3.2.beta1
+version = 2.3.2
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/src/IntuneCD/backup/Intune/Applications.py
+++ b/src/IntuneCD/backup/Intune/Applications.py
@@ -63,7 +63,8 @@ class ApplicationsBackupModule(BaseBackupModule):
         )
 
         # as we must process each app individually, get the audit data up front
-        self.audit_data = self.make_audit_request(self.audit_filter)
+        if self.audit:
+            self.audit_data = self.make_audit_request(self.audit_filter)
 
         for app in self.graph_data["value"]:
             platform = None

--- a/src/IntuneCD/backup/Intune/SettingsCatalog.py
+++ b/src/IntuneCD/backup/Intune/SettingsCatalog.py
@@ -27,6 +27,7 @@ class SettingsCatalogBackupModule(BaseBackupModule):
         )
         self.assignment_endpoint = "deviceManagement/configurationPolicies/"
         self.assignment_extra_url = "/assignments"
+        self.config_audit_data = True
 
     def main(self) -> dict[str, any]:
         """The main method to backup the Settings Catalog
@@ -52,7 +53,8 @@ class SettingsCatalogBackupModule(BaseBackupModule):
             item_ids_dict, self.assignment_endpoint, self.assignment_extra_url
         )
         # As we need to process each item individually, get the audit data up front
-        self.audit_data = self.make_audit_request(self.audit_filter)
+        if self.audit:
+            self.audit_data = self.make_audit_request(self.audit_filter)
         # Get the settings for each policy using batch request
         policy_responses = self.batch_request(
             item_ids, "deviceManagement/configurationPolicies/", "/settings?&top=1000"

--- a/src/IntuneCD/intunecdlib/IntuneCDBase.py
+++ b/src/IntuneCD/intunecdlib/IntuneCDBase.py
@@ -47,7 +47,7 @@ class IntuneCDBase:
         if "VPPusedLicenseCount" in self.exclude:
             keys.add("usedLicenseCount")
         if "GPlaySyncTime" in self.exclude:
-            keys.add("lastSyncDateTime")
+            keys.add("lastAppSyncDateTime")
         if "CompliancePartnerHeartbeat" in self.exclude:
             keys.add("lastHeartbeatDateTime")
 


### PR DESCRIPTION
## Fixes
- Audit was processed for Applications and Settings Catalog payloads as data is being pre-fetched in these modules. An additional check has been added to ensure audit is configured using arguments before getting data.
- Managed Google Play last sync time was being included even when excluded with `-e GPlaySyncTime` because the incorrect key was being removed.

closes #195 