### PR TITLE
v2.3.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 2.3.2
+version = 2.3.3.beta1
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 2.3.3.beta1
+version = 2.3.3.beta2
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 2.3.3.beta2
+version = 2.3.3
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/src/IntuneCD/intunecdlib/BaseGraphModule.py
+++ b/src/IntuneCD/intunecdlib/BaseGraphModule.py
@@ -852,7 +852,7 @@ class BaseGraphModule(IntuneCDBase):
                         val["target"]["groupId"] = request["id"]
 
             # Request filter id based on filter name
-            if val["target"]["deviceAndAppManagementAssignmentFilterId"]:
+            if "deviceAndAppManagementAssignmentFilterId" in val["target"]:
                 filters = self.make_graph_request(
                     endpoint="https://graph.microsoft.com/beta/deviceManagement/assignmentFilters",
                 )
@@ -861,9 +861,9 @@ class BaseGraphModule(IntuneCDBase):
                         val["target"]["deviceAndAppManagementAssignmentFilterId"]
                         == intune_filter["displayName"]
                     ):
-                        val["target"][
-                            "deviceAndAppManagementAssignmentFilterId"
-                        ] = intune_filter["id"]
+                        val["target"]["deviceAndAppManagementAssignmentFilterId"] = (
+                            intune_filter["id"]
+                        )
 
                 # If filter is None, remove keys
                 if val["target"]["deviceAndAppManagementAssignmentFilterId"] is None:

--- a/src/IntuneCD/intunecdlib/BaseGraphModule.py
+++ b/src/IntuneCD/intunecdlib/BaseGraphModule.py
@@ -861,9 +861,9 @@ class BaseGraphModule(IntuneCDBase):
                         val["target"]["deviceAndAppManagementAssignmentFilterId"]
                         == intune_filter["displayName"]
                     ):
-                        val["target"]["deviceAndAppManagementAssignmentFilterId"] = (
-                            intune_filter["id"]
-                        )
+                        val["target"][
+                            "deviceAndAppManagementAssignmentFilterId"
+                        ] = intune_filter["id"]
 
                 # If filter is None, remove keys
                 if val["target"]["deviceAndAppManagementAssignmentFilterId"] is None:

--- a/src/IntuneCD/intunecdlib/assignment_report.py
+++ b/src/IntuneCD/intunecdlib/assignment_report.py
@@ -71,7 +71,7 @@ class AssignmentReport(BaseBackupModule):
                 if not payload_added:
                     group_data["assignedTo"][payload_type] = [payload_data]
                     groups.append(group_data)
-                    break
+                    # break
 
     def _collect_groups(self, path):
         exclude = set(["__archive__", "Entra"])

--- a/src/IntuneCD/update/Intune/DeviceConfigurations.py
+++ b/src/IntuneCD/update/Intune/DeviceConfigurations.py
@@ -24,7 +24,7 @@ class DeviceConfigurationsUpdateModule(BaseUpdateModule):
         super().__init__(*args, **kwargs)
         self.path = f"{self.path}/Device Configurations/"
         self.assignment_endpoint = "/deviceManagement/deviceConfigurations/"
-        self.assignment_extra_url = "/assignments"
+        self.assignment_extra_url = "/assign"
         self.exclude_paths = [
             "root['assignments']",
             "root['payload']",


### PR DESCRIPTION
### Fixed
- Filters were not removed from assignment updates if they were "none"
- Assignment report did not add all groups to the report
- Device configurations assignments url changed from `/assignments` to `/assign` 