### PR TITLE
v2.3.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 2.3.3
+version = 2.3.4.beta1
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 2.3.4.beta2
+version = 2.3.4
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 2.3.4.beta1
+version = 2.3.4.beta2
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/src/IntuneCD/intunecdlib/BaseUpdateModule.py
+++ b/src/IntuneCD/intunecdlib/BaseUpdateModule.py
@@ -387,16 +387,17 @@ class BaseUpdateModule(BaseGraphModule):
         self.log(msg=f"Created with id: {self.create_request['id']}")
 
         if self.handle_assignment:
-            self.handle_assignments(
-                repo_assignments, [], self.assignment_key, self.create_request["id"]
-            )
-        if self.handle_iterable_assignment:
-            self.handle_iterable_assignments(
-                repo_assignments,
-                [],
-                self.assignment_key,
-                self.create_request["id"],
-            )
+            if self.config_type == "Windows Enrollment Profile":
+                self.handle_iterable_assignments(
+                    repo_assignments,
+                    [],
+                    self.assignment_key,
+                    self.create_request["id"],
+                )
+            else:
+                self.handle_assignments(
+                    repo_assignments, [], self.assignment_key, self.create_request["id"]
+                )
 
     def get_match_data(self, intune_data: dict, match_info: dict) -> tuple:
         """Gets the matching data

--- a/src/IntuneCD/intunecdlib/BaseUpdateModule.py
+++ b/src/IntuneCD/intunecdlib/BaseUpdateModule.py
@@ -664,19 +664,20 @@ class BaseUpdateModule(BaseGraphModule):
                 )
 
             if self.handle_assignment:
-                self.handle_assignments(
-                    repo_assignments,
-                    self.downstream_assignments,
-                    self.assignment_key,
-                    self.downstream_id,
-                )
-            if self.handle_iterable_assignment:
-                self.handle_iterable_assignments(
-                    repo_assignments,
-                    self.downstream_assignments,
-                    self.assignment_key,
-                    self.downstream_id,
-                )
+                if self.config_type == "Windows Enrollment Profile":
+                    self.handle_iterable_assignments(
+                        repo_assignments,
+                        self.downstream_assignments,
+                        self.assignment_key,
+                        self.downstream_id,
+                    )
+                else:
+                    self.handle_assignments(
+                        repo_assignments,
+                        self.downstream_assignments,
+                        self.assignment_key,
+                        self.downstream_id,
+                    )
 
             # Add scheduledActionsForRule back to the data if it was removed
             if repo_scheduled_actions:

--- a/src/IntuneCD/intunecdlib/IntuneCDBase.py
+++ b/src/IntuneCD/intunecdlib/IntuneCDBase.py
@@ -2,6 +2,7 @@
 import base64
 import json
 import os
+import sys
 import time
 
 import yaml
@@ -168,6 +169,7 @@ class IntuneCDBase:
             msg (str): The message to print to the console.
             tag (str): The tag to use for the log message. Defaults to "info".
         """
+        exit_on_error = os.getenv("EXIT_ON_ERROR")
         verbose = os.getenv("VERBOSE")
         if verbose:
             msg = (
@@ -180,6 +182,9 @@ class IntuneCDBase:
         if function is None and not verbose:
             msg = f"{time.asctime()} [{tag.upper()}] {msg}"
             print(msg)
+
+        if tag == "error" and exit_on_error:
+            sys.exit(1)
 
     def get_pop_keys(self, data: dict, keys: list[str], method: str = "get") -> None:
         """A method to get or pop keys from a dictionary

--- a/src/IntuneCD/run_backup.py
+++ b/src/IntuneCD/run_backup.py
@@ -200,11 +200,19 @@ def start():
         help="The authentication token to use for the update if not using an app registration",
         type=str,
     )
+    parser.add_argument(
+        "--exit-on-error",
+        help="When set, the script will exit on the first error",
+        action="store_true",
+    )
 
     args = parser.parse_args()
 
     if args.verbose:
         os.environ["VERBOSE"] = "True"
+
+    if args.exit_on_error:
+        os.environ["EXIT_ON_ERROR"] = "True"
 
     def devtoprod():
         return "devtoprod"
@@ -317,6 +325,9 @@ def start():
 
     if "VERBOSE" in os.environ:
         del os.environ["VERBOSE"]
+
+    if "EXIT_ON_ERROR" in os.environ:
+        del os.environ["EXIT_ON_ERROR"]
 
 
 if __name__ == "__main__":

--- a/src/IntuneCD/run_update.py
+++ b/src/IntuneCD/run_update.py
@@ -170,11 +170,19 @@ def start():
         help="The authentication token to use for the update if not using an app registration",
         type=str,
     )
+    parser.add_argument(
+        "--exit-on-error",
+        help="When this parameter is set, IntuneCD will exit on error",
+        action="store_true",
+    )
 
     args = parser.parse_args()
 
     if args.verbose:
         os.environ["VERBOSE"] = "True"
+
+    if args.exit_on_error:
+        os.environ["EXIT_ON_ERROR"] = "True"
 
     def devtoprod():
         return "devtoprod"
@@ -315,6 +323,8 @@ def start():
 
     if "VERBOSE" in os.environ:
         del os.environ["VERBOSE"]
+    if "EXIT_ON_ERROR" in os.environ:
+        del os.environ["EXIT_ON_ERROR"]
 
 
 if __name__ == "__main__":

--- a/src/IntuneCD/update/Intune/EnrollmentStatusPage.py
+++ b/src/IntuneCD/update/Intune/EnrollmentStatusPage.py
@@ -47,7 +47,7 @@ class EnrollmentStatusPageUpdateModule(BaseUpdateModule):
 
             for app in repo_data["selectedMobileAppNames"]:
                 param = {
-                    "$filter": f"(isof('{str(app['type']).replace('#','')}'))",
+                    "$filter": f"(isof('{str(app['type']).replace('#', '')}'))",
                     "$search": '"' + app["name"] + '"',
                 }
 

--- a/src/IntuneCD/update/Intune/WindowsEnrollmentProfile.py
+++ b/src/IntuneCD/update/Intune/WindowsEnrollmentProfile.py
@@ -81,9 +81,10 @@ class WindowsEnrollmentProfileUpdateModule(BaseUpdateModule):
                     self.reset_diffs_and_count()
 
             for item in intune_data["value"]:
-                # Remvoe any assignments before removing the profile
-                endpoint = f"{self.endpoint}{self.CONFIG_ENDPOINT}{item['id']}{self.assignment_extra_url}"
-                self.make_graph_request(endpoint, method="delete", status_code=200)
+                if self.remove:
+                    # Remvoe any assignments before removing the profile
+                    endpoint = f"{self.endpoint}{self.CONFIG_ENDPOINT}{item['id']}{self.assignment_extra_url}"
+                    self.make_graph_request(endpoint, method="delete", status_code=200)
             self.remove_downstream_data(self.CONFIG_ENDPOINT, intune_data["value"])
 
         return self.diff_summary

--- a/src/IntuneCD/update/Intune/WindowsEnrollmentProfile.py
+++ b/src/IntuneCD/update/Intune/WindowsEnrollmentProfile.py
@@ -32,7 +32,6 @@ class WindowsEnrollmentProfileUpdateModule(BaseUpdateModule):
             "root['assignments']",
         ]
         # Windows enrollment profile assginment is handled differently, so we need to set the following attributes
-        self.handle_assignment = False
         self.handle_iterable_assignment = True
         self.assignment_key = "target"
         self.assignment_status_code = 201


### PR DESCRIPTION
### Added
- Option to exit if error occurs, configured using a new argument `--exit-on-error` #206 
### Fixes
- Windows Enrollment Profiles assignments were update even when `-u` was not used #205 
- Windows Enrollment Profiles assignments were removed even when `--remove` was not used if the config did not exist in the repo #205 

closes #206 
closes #205 