### PR TITLE
v2.3.5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 2.3.5.beta1
+version = 2.3.5
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 2.3.4
+version = 2.3.5.beta1
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,12 +20,12 @@ package_dir =
 packages = find:
 python_requires = >=3.9
 install_requires =
-    deepdiff>=5.6.0
-    pyyaml>=6.0
+    deepdiff==8.0.1
+    pyyaml>=6.0.2
     msrest>=0.6.21
     markdown_toclify>=0.1.7
-    pytablewriter>=0.64.1
-    msal >= 1.20.0
+    pytablewriter>=1.2.0
+    msal>=1.30.0
 
 [options.packages.find]
 where = src

--- a/src/IntuneCD/backup/Intune/Roles.py
+++ b/src/IntuneCD/backup/Intune/Roles.py
@@ -87,7 +87,7 @@ class RolesBackupModule(BaseBackupModule):
                             f"{self.endpoint}/beta/deviceManagement/roleAssignments/{assignment['id']}",
                         )
 
-                    item["roleAssignments"].append(role_assignment)
+                        item["roleAssignments"].append(role_assignment)
 
                     # Get the scopeMembers and resourceScopes ids
                     scope_member_names = ""
@@ -103,11 +103,8 @@ class RolesBackupModule(BaseBackupModule):
                             assignment["scopeMembers"] = scope_member_names
                         assignment.pop("resourceScopes", None)
 
-                        for assignment in item["roleAssignments"]:
-                            if assignment.get("members"):
-                                member_names = self._get_group_names(
-                                    assignment["members"]
-                                )
+                        if assignment.get("members"):
+                            member_names = self._get_group_names(assignment["members"])
 
                         assignment["members"] = member_names
 

--- a/src/IntuneCD/update/Intune/CustomAttributes.py
+++ b/src/IntuneCD/update/Intune/CustomAttributes.py
@@ -50,16 +50,18 @@ class CustomAttributesUpdateModule(BaseUpdateModule):
         if len(fname_id) > 1:
             fname_id = fname_id[1].replace(".json", "").replace(".yaml", "")
         else:
-            fname_id = ""
+            fname_id = None
         script_files = os.listdir(self.script_data_path)
-        script_file = [
-            x for x in script_files if fname_id in x or repo_data["fileName"] in x
-        ]
 
-        if script_file:
+        if not fname_id:
+            script_file = [x for x in script_files if repo_data["fileName"] in x]
+        else:
+            script_file = [x for x in script_files if fname_id in x]
+
+        if len(script_file) == 1:
             return script_file[0]
 
-        return ""
+        return None
 
     def _handle_script_diffs(
         self, repo_script: str, intune_script: str, repo_data: dict[str, any]
@@ -102,6 +104,8 @@ class CustomAttributesUpdateModule(BaseUpdateModule):
             )
 
             for filename in os.listdir(self.path):
+                self.notify = True
+                script_data = None
                 repo_data = self.load_repo_data(filename)
                 if repo_data:
                     self.match_info = {

--- a/src/IntuneCD/update/Intune/PowerShellScripts.py
+++ b/src/IntuneCD/update/Intune/PowerShellScripts.py
@@ -44,13 +44,15 @@ class PowerShellScriptsUpdateModule(BaseUpdateModule):
         if len(fname_id) > 1:
             fname_id = fname_id[1].replace(".json", "").replace(".yaml", "")
         else:
-            fname_id = ""
+            fname_id = None
         script_files = os.listdir(self.script_data_path)
-        script_file = [
-            x for x in script_files if fname_id in x or repo_data["fileName"] in x
-        ]
 
-        if script_file:
+        if not fname_id:
+            script_file = [x for x in script_files if repo_data["fileName"] in x]
+        else:
+            script_file = [x for x in script_files if fname_id in x]
+
+        if len(script_file) == 1:
             return script_file[0]
 
         return ""
@@ -97,6 +99,7 @@ class PowerShellScriptsUpdateModule(BaseUpdateModule):
 
             for filename in os.listdir(self.path):
                 self.notify = True
+                script_data = None
                 repo_data = self.load_repo_data(filename)
                 if repo_data:
                     self.match_info = {

--- a/src/IntuneCD/update/Intune/ShellScripts.py
+++ b/src/IntuneCD/update/Intune/ShellScripts.py
@@ -44,16 +44,18 @@ class ShellScriptsUpdateModule(BaseUpdateModule):
         if len(fname_id) > 1:
             fname_id = fname_id[1].replace(".json", "").replace(".yaml", "")
         else:
-            fname_id = ""
+            fname_id = None
         script_files = os.listdir(self.script_data_path)
-        script_file = [
-            x for x in script_files if fname_id in x or repo_data["fileName"] in x
-        ]
 
-        if script_file:
+        if not fname_id:
+            script_file = [x for x in script_files if repo_data["fileName"] in x]
+        else:
+            script_file = [x for x in script_files if fname_id in x]
+
+        if len(script_file) == 1:
             return script_file[0]
 
-        return ""
+        return None
 
     def _handle_script_diffs(
         self, repo_script: str, intune_script: str, repo_data: dict[str, any]
@@ -96,6 +98,8 @@ class ShellScriptsUpdateModule(BaseUpdateModule):
             )
 
             for filename in os.listdir(self.path):
+                self.notify = True
+                script_data = None
                 repo_data = self.load_repo_data(filename)
                 if repo_data:
                     self.match_info = {


### PR DESCRIPTION
## Fixes
- Script policies could potentially be updated with incorrect script content due to not using the correct script file for diff check #211 
- If a role had multiple assignments only the last in the list were included in the backup

## Other updates
- Version requirements for dependencies has been updated, DeepDiff has been locked to require a specific version to avoid issues like #210 

Closes #211 