### PR TITLE
v2.3.6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 2.3.6.beta1
+version = 2.3.6
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 2.3.5
+version = 2.3.6.beta1
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/src/IntuneCD/update/Intune/SettingsCatalog.py
+++ b/src/IntuneCD/update/Intune/SettingsCatalog.py
@@ -50,7 +50,9 @@ class SettingsCatalogUpdateModule(BaseUpdateModule):
                 profile_ids, "deviceManagement/configurationPolicies/", ""
             )
             batch_settings = self.batch_request(
-                profile_ids, "deviceManagement/configurationPolicies/", "/settings"
+                profile_ids,
+                "deviceManagement/configurationPolicies/",
+                "/settings?&top=1000",
             )
 
             for profile in batch_data:


### PR DESCRIPTION
## Fixes
- Security baselines had changes pushed even when there were no changes made. This was due to a paging issue where not all settings were included for diff check thus adding settings that were already there https://github.com/almenscorner/IntuneCD/issues/214

closes #214 