### PR TITLE
Improve Audit Commit Message

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ The core functionality of IntuneCD revolves around securely backing up Intune co
 
 By leveraging IntuneCD, users can streamline their configuration management workflow, ensuring smooth and consistent deployment of settings while maintaining an auditable history of changes.
 
-# Exciting news 📣
-The front end for IntuneCD has now been released. Check it out [here](https://github.com/almenscorner/intunecd-monitor)
+# Looking for a GUI?
+Check out the front end for IntuneCD [here](https://github.com/almenscorner/intunecd-monitor)
 
 ***
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,8 @@
 [![Downloads](https://static.pepy.tech/badge/intunecd)](https://pepy.tech/project/intunecd)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/IntuneCD?style=flat-square)
 ![PyPI](https://img.shields.io/pypi/v/IntuneCD?style=flat-square)
-![Maintenance](https://img.shields.io/maintenance/yes/2024?style=flat-square)
 ![Unit tests](https://github.com/almenscorner/IntuneCD/actions/workflows/unit-test.yml/badge.svg)
 ![Publish](https://github.com/almenscorner/IntuneCD/actions/workflows/pypi-publish.yml/badge.svg)
-[![codecov](https://codecov.io/gh/almenscorner/IntuneCD/branch/main/graph/badge.svg?token=SNTOJ0N5MU)](https://codecov.io/gh/almenscorner/IntuneCD)
 
 <p align="center">
   <img src="https://user-images.githubusercontent.com/78877636/204297420-4b5373a8-4864-4710-a4a5-802ea4ec08d5.png#gh-dark-mode-only" width="500" height="300">

--- a/src/IntuneCD/intunecdlib/BaseGraphModule.py
+++ b/src/IntuneCD/intunecdlib/BaseGraphModule.py
@@ -189,7 +189,7 @@ class BaseGraphModule(IntuneCDBase):
                 f"{audit_filter} and activityDateTime gt {start_date} and activityDateTime le {end_date} and "
                 "activityOperationType ne 'Get'"
             ),
-            "$select": "actor,activityDateTime,activityOperationType,activityResult,resources",
+            "$select": "actor,activityDateTime,activityType,activityOperationType,activityResult,resources",
             "$orderby": "activityDateTime desc",
         }
         self.log(function="makeAuditRequest", msg=f"Query parameters: {q_param}")
@@ -218,6 +218,7 @@ class BaseGraphModule(IntuneCDBase):
                         ],
                         "actor": actor,
                         "activityDateTime": audit_log["activityDateTime"],
+                        "activityType": audit_log["activityType"],
                         "activityOperationType": audit_log["activityOperationType"],
                         "activityResult": audit_log["activityResult"],
                     }

--- a/src/IntuneCD/intunecdlib/process_audit_data.py
+++ b/src/IntuneCD/intunecdlib/process_audit_data.py
@@ -155,7 +155,7 @@ class ProcessAuditData(IntuneCDBase):
             "commit",
             "-m",
             (
-                f"{audit_record['auditResourceType']} {audit_record['activityOperationType']} by {audit_record['actor']}\n"
+                f"{audit_record['activityType']} by {audit_record['actor']}\n"
                 f"Date: {audit_record['activityDateTime']}\n"
                 f"result: {audit_record['activityResult']}"
             ),


### PR DESCRIPTION
this results in these commits.
![image](https://github.com/user-attachments/assets/3ce91ada-a63a-4829-b986-d7a08146ff77)
![image](https://github.com/user-attachments/assets/dc12ca9d-7a71-4d84-8f6c-ad1d08381a80)
instead of this (which implies that the entire policy was deleted instead of just the policy assignment)
![image](https://github.com/user-attachments/assets/0ac3aa6d-c68c-4598-9931-2ecb375f4ae3)

I think the activityType better reflects the audit message then the current settings, what do you think?
![image](https://github.com/user-attachments/assets/0bcce7bf-4012-447a-a31e-9a25fb52f619)
![image](https://github.com/user-attachments/assets/c8826bf6-9883-4b66-b1f4-4ce2729d025f)