### PR TITLE
Feature/improve settings catalog documentation readability

### DIFF
--- a/src/IntuneCD/backup/Intune/SettingsCatalog.py
+++ b/src/IntuneCD/backup/Intune/SettingsCatalog.py
@@ -138,11 +138,13 @@ class SettingsCatalogBackupModule(BaseBackupModule):
 
         # Retrieve all definitions from Graph and build a map
         definition_map = {}
-        for def_id in all_definition_ids:
-            try:
-                definition = self.make_graph_request(
-                    endpoint=f"{self.endpoint}/beta/deviceManagement/configurationSettings/{def_id}"
-                )
+        try:
+            # Batch request for all definitionIds
+            batched_definitions = self.make_graph_request(
+                endpoint=f"{self.endpoint}/beta/deviceManagement/configurationSettings",
+                params={"ids": ",".join(all_definition_ids)}
+            )
+            for definition in batched_definitions.get("value", []):
                 entry = {
                     "id": definition.get("id", ""),
                     "name": definition.get("name", ""),

--- a/src/IntuneCD/backup/Intune/SettingsCatalog.py
+++ b/src/IntuneCD/backup/Intune/SettingsCatalog.py
@@ -108,10 +108,10 @@ class SettingsCatalogBackupModule(BaseBackupModule):
         # Collect unique setting definition IDs to batch request definitions
         definition_ids = set()
         for setting in settings:
-            if "settingDefinitions" in setting:
-                for definition in setting["settingDefinitions"]:
-                    if "id" in definition:
-                        definition_ids.add(definition["id"])
+            if "settingInstance" in setting:
+                setting_instance = setting["settingInstance"]
+                if "settingDefinitionId" in setting_instance:
+                    definition_ids.add(setting_instance["settingDefinitionId"])
         
         if not definition_ids:
             return settings
@@ -151,16 +151,17 @@ class SettingsCatalogBackupModule(BaseBackupModule):
             enriched_settings = []
             for setting in settings:
                 enriched_setting = setting.copy()
-                if "settingDefinitions" in setting:
-                    enriched_definitions = []
-                    for definition in setting["settingDefinitions"]:
-                        if "id" in definition and definition["id"] in definition_map:
-                            enriched_definition = definition.copy()
-                            enriched_definition.update(definition_map[definition["id"]])
-                            enriched_definitions.append(enriched_definition)
-                        else:
-                            enriched_definitions.append(definition)
-                    enriched_setting["settingDefinitions"] = enriched_definitions
+                if "settingInstance" in setting:
+                    setting_instance = setting["settingInstance"]
+                    if "settingDefinitionId" in setting_instance:
+                        definition_id = setting_instance["settingDefinitionId"]
+                        if definition_id in definition_map:
+                            # Add settingDefinitions array to maintain compatibility with documentation
+                            enriched_setting["settingDefinitions"] = [{
+                                "id": definition_id,
+                                "displayName": definition_map[definition_id]["displayName"],
+                                "description": definition_map[definition_id]["description"]
+                            }]
                 enriched_settings.append(enriched_setting)
                 
             return enriched_settings

--- a/src/IntuneCD/backup/Intune/SettingsCatalog.py
+++ b/src/IntuneCD/backup/Intune/SettingsCatalog.py
@@ -159,6 +159,22 @@ class SettingsCatalogBackupModule(BaseBackupModule):
                             "displayName": option.get("displayName", ""),
                             "value": option.get("optionValue", {}).get("value", None)
                         })
+                # Add categoryDisplayName for the main (root) setting definition
+                if "categoryId" in definition:
+                    try:
+                        rootCategoryId = self.make_graph_request(
+                            endpoint=f"{self.endpoint}/beta/deviceManagement/configurationCategories/{definition['categoryId']}?$select=rootCategoryId"
+                        )
+                        category = self.make_graph_request(
+                            endpoint=f"{self.endpoint}/beta/deviceManagement/configurationCategories/{rootCategoryId['rootCategoryId']}?$select=displayName"
+                        )
+                        entry["categoryDisplayName"] = category.get("displayName", "")
+                    except Exception as e:
+                        self.log(
+                            tag="warning",
+                            msg=f"Could not retrieve category for {def_id}: {e}"
+                        )
+                        entry["categoryDisplayName"] = ""
                 definition_map[def_id] = entry
             except Exception as e:
                 self.log(

--- a/src/IntuneCD/backup/Intune/SettingsCatalog.py
+++ b/src/IntuneCD/backup/Intune/SettingsCatalog.py
@@ -138,13 +138,11 @@ class SettingsCatalogBackupModule(BaseBackupModule):
 
         # Retrieve all definitions from Graph and build a map
         definition_map = {}
-        try:
-            # Batch request for all definitionIds
-            batched_definitions = self.make_graph_request(
-                endpoint=f"{self.endpoint}/beta/deviceManagement/configurationSettings",
-                params={"ids": ",".join(all_definition_ids)}
-            )
-            for definition in batched_definitions.get("value", []):
+        for def_id in all_definition_ids:
+            try:
+                definition = self.make_graph_request(
+                    endpoint=f"{self.endpoint}/beta/deviceManagement/configurationSettings/{def_id}"
+                )
                 entry = {
                     "id": definition.get("id", ""),
                     "name": definition.get("name", ""),
@@ -174,16 +172,16 @@ class SettingsCatalogBackupModule(BaseBackupModule):
                     except Exception as e:
                         self.log(
                             tag="warning",
-                            msg=f"Could not retrieve category for {definition['id']}: {e}"
+                            msg=f"Could not retrieve category for {def_id}: {e}"
                         )
                         entry["categoryDisplayName"] = ""
-                definition_map[definition['id']] = entry
-        except Exception as e:
-            self.log(
-                tag="warning",
-                msg=f"Could not retrieve definition for {definition['id']}: {e}"
-            )
-
+                definition_map[def_id] = entry
+            except Exception as e:
+                self.log(
+                    tag="warning",
+                    msg=f"Could not retrieve definition for {def_id}: {e}"
+                )
+                continue
 
         # Add all relevant definitions to each setting
         enriched_settings = []

--- a/src/IntuneCD/backup/Intune/SettingsCatalog.py
+++ b/src/IntuneCD/backup/Intune/SettingsCatalog.py
@@ -174,15 +174,14 @@ class SettingsCatalogBackupModule(BaseBackupModule):
                     except Exception as e:
                         self.log(
                             tag="warning",
-                            msg=f"Could not retrieve category for {definition}: {e}"
+                            msg=f"Could not retrieve category for {definition['id']}: {e}"
                         )
                         entry["categoryDisplayName"] = ""
-                definition_map[definition] = entry
+                definition_map[definition['id']] = entry
         except Exception as e:
             self.log(
                 tag="warning",
-                msg=f"Could not retrieve definition for {definition}: {e}"
-                continue
+                msg=f"Could not retrieve definition for {definition['id']}: {e}"
             )
 
 

--- a/src/IntuneCD/backup/Intune/SettingsCatalog.py
+++ b/src/IntuneCD/backup/Intune/SettingsCatalog.py
@@ -174,16 +174,17 @@ class SettingsCatalogBackupModule(BaseBackupModule):
                     except Exception as e:
                         self.log(
                             tag="warning",
-                            msg=f"Could not retrieve category for {def_id}: {e}"
+                            msg=f"Could not retrieve category for {definition}: {e}"
                         )
                         entry["categoryDisplayName"] = ""
-                definition_map[def_id] = entry
-            except Exception as e:
-                self.log(
-                    tag="warning",
-                    msg=f"Could not retrieve definition for {def_id}: {e}"
-                )
+                definition_map[definition] = entry
+        except Exception as e:
+            self.log(
+                tag="warning",
+                msg=f"Could not retrieve definition for {definition}: {e}"
                 continue
+            )
+
 
         # Add all relevant definitions to each setting
         enriched_settings = []

--- a/src/IntuneCD/document_intune.py
+++ b/src/IntuneCD/document_intune.py
@@ -66,7 +66,7 @@ def document_intune(
         ("Scripts/Shell", "Shell Scripts"),
         ("Custom Attributes", "Custom Attributes"),
         ("Scripts/Powershell", "Powershell Scripts"),
-        # Note: Settings Catalog is now handled separately like Management Intents
+        ("Settings Catalog", "Settings Catalog"),
         ("Driver Updates", "Windows Driver Updates"),
         ("Feature Updates", "Windows Feature Updates"),
         ("Quality Updates", "Windows Quality Updates"),
@@ -115,11 +115,7 @@ def document_intune(
                 split_per_config,
             )
 
-    # **Run Management Intents and Settings Catalog Sequentially**
-    # These require special handling for settings documentation
+    # **Run Management Intents Sequentially**
     document_management_intents(
         f"{configpath}/Management Intents/", outpath, "Management Intents", split
-    )
-    document_management_intents(
-        f"{configpath}/Settings Catalog/", outpath, "Settings Catalog", split
     )

--- a/src/IntuneCD/document_intune.py
+++ b/src/IntuneCD/document_intune.py
@@ -4,6 +4,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from .intunecdlib.documentation_functions import (
     document_configs,
     document_management_intents,
+    document_settings_catalog,
 )
 from .decorators import time_command
 
@@ -66,7 +67,6 @@ def document_intune(
         ("Scripts/Shell", "Shell Scripts"),
         ("Custom Attributes", "Custom Attributes"),
         ("Scripts/Powershell", "Powershell Scripts"),
-        ("Settings Catalog", "Settings Catalog"),
         ("Driver Updates", "Windows Driver Updates"),
         ("Feature Updates", "Windows Feature Updates"),
         ("Quality Updates", "Windows Quality Updates"),
@@ -118,4 +118,9 @@ def document_intune(
     # **Run Management Intents Sequentially**
     document_management_intents(
         f"{configpath}/Management Intents/", outpath, "Management Intents", split
+    )
+    
+    # **Run Settings Catalog with specialized documentation**
+    document_settings_catalog(
+        f"{configpath}/Settings Catalog/", outpath, "Settings Catalog", split, split_per_config
     )

--- a/src/IntuneCD/document_intune.py
+++ b/src/IntuneCD/document_intune.py
@@ -66,7 +66,7 @@ def document_intune(
         ("Scripts/Shell", "Shell Scripts"),
         ("Custom Attributes", "Custom Attributes"),
         ("Scripts/Powershell", "Powershell Scripts"),
-        ("Settings Catalog", "Settings Catalog"),
+        # Note: Settings Catalog is now handled separately like Management Intents
         ("Driver Updates", "Windows Driver Updates"),
         ("Feature Updates", "Windows Feature Updates"),
         ("Quality Updates", "Windows Quality Updates"),
@@ -115,7 +115,11 @@ def document_intune(
                 split_per_config,
             )
 
-    # **Run Management Intents Sequentially**
+    # **Run Management Intents and Settings Catalog Sequentially**
+    # These require special handling for settings documentation
     document_management_intents(
         f"{configpath}/Management Intents/", outpath, "Management Intents", split
+    )
+    document_management_intents(
+        f"{configpath}/Settings Catalog/", outpath, "Settings Catalog", split
     )

--- a/src/IntuneCD/intunecdlib/documentation_functions.py
+++ b/src/IntuneCD/intunecdlib/documentation_functions.py
@@ -660,7 +660,7 @@ def document_settings_catalog(
     """
     Specialized documentation function for Settings Catalog policies.
     Creates simplified configuration sections and organized setting tables by category.
-    
+
     :param configpath: Path to backup files
     :param outpath: Base path for Markdown output
     :param header: Configuration type header
@@ -707,7 +707,7 @@ def document_settings_catalog(
 
             # Prepare assignments table
             assignments_table = assignment_table(repo_data)
-            
+
             # Extract basic policy information
             policy_name = repo_data.get("name", "Unknown Policy")
             description = repo_data.get("description", "")
@@ -716,7 +716,7 @@ def document_settings_catalog(
             scope_tags = repo_data.get("roleScopeTagIds", [])
             created_date = repo_data.get("createdDateTime", "")
             modified_date = repo_data.get("lastModifiedDateTime", "")
-            
+
             # Create basic policy info table
             basics_table_data = [
                 ["Name", policy_name],
@@ -726,16 +726,16 @@ def document_settings_catalog(
                 ["Technologies", technologies],
                 ["Scope tags", ", ".join(scope_tags) if scope_tags else "Default"]
             ]
-            
+
             # Add dates if available
             if created_date:
                 basics_table_data.append(["Created", _format_date(created_date)])
             if modified_date:
                 basics_table_data.append(["Last modified", _format_date(modified_date)])
-            
+
             # Remove None entries
             basics_table_data = [item for item in basics_table_data if item is not None]
-            
+
             basics_table = _write_clean_table(["Setting", "Value"], basics_table_data)
 
             # Process settings by category
@@ -767,14 +767,14 @@ def document_settings_catalog(
             # Write to file
             with open(target_md, "a", encoding="utf-8") as md:
                 md.write(top_header + "\n\n")
-                
+
                 if assignments_table:
                     md.write("#### Assignments\n")
                     md.write(str(assignments_table) + "\n\n")
-                
+
                 md.write("#### Basics\n")
                 md.write(str(basics_table) + "\n\n")
-                
+
                 # Write single configuration table
                 if settings_tables:
                     # There should only be one table now
@@ -791,7 +791,7 @@ def _format_platform(platform):
     platform_map = {
         "windows10": "Windows 10 and later",
         "macOS": "macOS",
-        "iOS": "iOS/iPadOS", 
+        "iOS": "iOS/iPadOS",
         "android": "Android"
     }
     return platform_map.get(platform, platform)
@@ -812,22 +812,22 @@ def _process_settings_catalog_settings(settings):
     """
     Process Settings Catalog settings to extract readable names and values.
     This function is used primarily for testing the setting processing logic.
-    
+
     :param settings: List of settings from Settings Catalog policy
     :return: List of [name, value] pairs
     """
     if not settings:
         return []
-    
+
     processed_settings = []
-    
+
     for setting in settings:
         if "settingInstance" not in setting:
             continue
-            
+
         setting_instance = setting["settingInstance"]
         setting_definition_id = setting_instance.get("settingDefinitionId", "")
-        
+
         # Extract display name from enriched data or use fallback formatting
         if "settingDefinitions" in setting and setting["settingDefinitions"]:
             # Use enriched display name if available
@@ -838,10 +838,10 @@ def _process_settings_catalog_settings(settings):
         else:
             # Fallback to formatting the ID - use simple formatting for test compatibility
             name_with_desc = _format_setting_name_for_tests(setting_definition_id)
-        
+
         # Extract value - use simple extraction for test compatibility
         value = _extract_setting_value_for_tests(setting_instance)
-        
+
         # Handle multi-value results from children
         if isinstance(value, list):
             # If there are multiple child values, create separate entries
@@ -850,7 +850,7 @@ def _process_settings_catalog_settings(settings):
                 processed_settings.append([child_name, str(child_value)])
         else:
             processed_settings.append([name_with_desc, str(value)])
-    
+
     return processed_settings
 
 
@@ -858,16 +858,16 @@ def _format_setting_name_for_tests(setting_definition_id):
     """
     Format setting definition ID into a readable name for test compatibility.
     This uses simpler logic than the main formatting function.
-    
+
     :param setting_definition_id: The setting definition ID
     :return: Formatted setting name
     """
     if not setting_definition_id:
         return "Unknown Setting"
-    
+
     # Extract the meaningful part from the ID
     parts = setting_definition_id.split("_")
-    
+
     # Find the last meaningful parts (usually after the category)
     if len(parts) > 3:
         # For test compatibility, take only the last 2 parts
@@ -878,7 +878,7 @@ def _format_setting_name_for_tests(setting_definition_id):
         name = re.sub(r'v(\d+)', r'V\1', name)  # Convert v2 to V2
         name = re.sub(r'([a-z])([A-Z])', r'\1 \2', name)  # Add spaces before capitals
         return name.title()
-    
+
     # Fallback to just converting underscores to spaces and title case
     return setting_definition_id.replace("_", " ").title()
 
@@ -887,7 +887,7 @@ def _extract_setting_value_for_tests(setting_instance):
     """
     Extract the value from a setting instance for test compatibility.
     This uses simpler logic than the main extraction function.
-    
+
     :param setting_instance: The setting instance object
     :return: Setting value
     """
@@ -904,30 +904,30 @@ def _extract_setting_value_for_tests(setting_instance):
         if isinstance(collection, list) and len(collection) > 0:
             return f"{len(collection)} items"
         return "Collection value"
-    
+
     return "Not configured"
 
 
 def _create_settings_tables(settings):
     """
     Create a single table from Settings Catalog settings.
-    
+
     :param settings: List of settings from the policy
     :return: List with single tuple ("Configuration", table)
     """
     if not settings:
         return []
-    
+
     # Collect all settings in a single list
     all_settings = []
-    
+
     for setting in settings:
         if "settingInstance" not in setting:
             continue
-            
+
         setting_instance = setting["settingInstance"]
         setting_definition_id = setting_instance.get("settingDefinitionId", "")
-        
+
         # Extract display name from enriched data or use fallback formatting
         if "settingDefinitions" in setting and setting["settingDefinitions"]:
             # Use enriched display name if available
@@ -937,10 +937,10 @@ def _create_settings_tables(settings):
             # Fallback to formatting the ID
             display_name = _format_setting_name(setting_definition_id)
             description = ""
-        
+
         # Extract value (now handles children properly)
         value = _extract_setting_value(setting_instance)
-        
+
         # Handle multi-value results from children
         if isinstance(value, list):
             # If there are multiple child values, create separate rows
@@ -951,12 +951,12 @@ def _create_settings_tables(settings):
         else:
             formatted_value = _format_value_for_markdown(value)
             all_settings.append([display_name, formatted_value, description])
-    
+
     # Create single table with all settings using clean formatting
     if all_settings:
         table = _write_clean_table(["Setting", "Value", "Description"], all_settings)
         return [("Configuration", table)]
-    
+
     return []
 
 
@@ -975,20 +975,20 @@ def _write_clean_table(headers, data):
 def _format_value_for_markdown(value):
     """
     Format setting value for markdown display, handling XML/JSON structures.
-    
+
     :param value: The setting value to format
     :return: Formatted value string
     """
     if not value or value == "Not configured":
         return value
-    
+
     value_str = str(value)
-    
+
     # Check if this looks like XML content
     if value_str.strip().startswith('<') and value_str.strip().endswith('>'):
         # Format as XML code block
         return f"```xml\n{value_str.strip()}\n```"
-    
+
     # Check if this looks like JSON content
     if (value_str.strip().startswith('{') and value_str.strip().endswith('}')) or \
        (value_str.strip().startswith('[') and value_str.strip().endswith(']')):
@@ -1001,28 +1001,28 @@ def _format_value_for_markdown(value):
         except Exception:
             # If parsing fails, treat as regular text
             pass
-    
+
     # For very long values (> 100 chars), use code block
     if len(value_str) > 100:
         return f"```\n{value_str}\n```"
-    
+
     return value_str
 
 
 def _extract_category_from_id(setting_definition_id):
     """
     Extract category name from setting definition ID.
-    
+
     :param setting_definition_id: The setting definition ID
     :return: Category name
     """
     if not setting_definition_id:
         return "Other Settings"
-    
+
     # Common patterns for extracting categories
     category_patterns = {
         "localpoliciessecurityoptions": "Local Policies Security Options",
-        "defender": "Microsoft Defender", 
+        "defender": "Microsoft Defender",
         "devicelock": "Device Lock",
         "wifi": "Wi-Fi",
         "bluetooth": "Bluetooth",
@@ -1034,15 +1034,15 @@ def _extract_category_from_id(setting_definition_id):
         "accounts": "Accounts",
         "applications": "Applications"
     }
-    
+
     # Convert to lowercase for matching
     id_lower = setting_definition_id.lower()
-    
+
     # Look for category patterns in the ID
     for pattern, category_name in category_patterns.items():
         if pattern in id_lower:
             return category_name
-    
+
     # Fallback: try to extract from policy config pattern
     if "policy_config_" in id_lower:
         # Extract the part after policy_config_
@@ -1051,27 +1051,27 @@ def _extract_category_from_id(setting_definition_id):
             category_part = parts[1].split("_")[0]
             # Convert to title case
             return category_part.replace("", " ").title()
-    
+
     return "Other Settings"
 
 
 def _format_setting_name(setting_definition_id):
     """
     Format setting definition ID into a readable name.
-    
+
     :param setting_definition_id: The setting definition ID
     :return: Formatted setting name
     """
     if not setting_definition_id:
         return "Unknown Setting"
-    
+
     # Special cases for well-known settings
     if "machineinactivitylimit" in setting_definition_id.lower():
         return "Interactive Logon Machine Inactivity Limit"
-    
+
     # Extract the meaningful part from the ID
     parts = setting_definition_id.split("_")
-    
+
     # Find the last meaningful parts (usually after the category)
     if len(parts) > 3:
         # Take the last 2-3 parts and format them
@@ -1082,7 +1082,7 @@ def _format_setting_name(setting_definition_id):
         name = re.sub(r'_v\d+$', '', name)  # Remove version suffix
         name = re.sub(r'([a-z])([A-Z])', r'\1 \2', name)  # Add spaces before capitals
         return name.title()
-    
+
     # Fallback to just converting underscores to spaces and title case
     return setting_definition_id.replace("_", " ").title()
 
@@ -1090,7 +1090,7 @@ def _format_setting_name(setting_definition_id):
 def _extract_setting_value(setting_instance):
     """
     Extract the value from a setting instance, including children values.
-    
+
     :param setting_instance: The setting instance object
     :return: Formatted setting value or list of child values
     """
@@ -1099,7 +1099,7 @@ def _extract_setting_value(setting_instance):
         return value if value != "" else "Not configured"
     elif "choiceSettingValue" in setting_instance:
         choice_value_obj = setting_instance["choiceSettingValue"]
-        
+
         # Check if there are children with actual values
         if "children" in choice_value_obj and choice_value_obj["children"]:
             child_values = []
@@ -1107,11 +1107,11 @@ def _extract_setting_value(setting_instance):
                 child_value = _extract_setting_value(child)
                 if child_value and child_value != "Not configured" and child_value != "":
                     child_values.append(child_value)
-            
+
             # If we found child values, return them; otherwise fall back to choice value
             if child_values:
                 return child_values if len(child_values) > 1 else child_values[0]
-        
+
         # Fallback to choice value
         choice_value = choice_value_obj.get("value", "")
         if choice_value:
@@ -1128,7 +1128,27 @@ def _extract_setting_value(setting_instance):
     elif "groupSettingCollectionValue" in setting_instance:
         collection = setting_instance["groupSettingCollectionValue"]
         if isinstance(collection, list) and len(collection) > 0:
-            return f"{len(collection)} items"
+            extracted = []
+            for item in collection:
+                # If the item has children, extract their values
+                if "children" in item and item["children"]:
+                    child_values = []
+                    for child in item["children"]:
+                        child_value = _extract_setting_value(child)
+                        if child_value and child_value != "Not configured" and child_value != "":
+                            child_values.append(child_value)
+                    if child_values:
+                        # If only one value, don't wrap in list
+                        extracted.append(child_values if len(child_values) > 1 else child_values[0])
+                else:
+                    # Fallback: try to extract value directly
+                    value = item.get("value", None)
+                    if value:
+                        extracted.append(value)
+            # Flatten if only one item
+            if len(extracted) == 1:
+                return extracted[0]
+            return extracted if extracted else "Not configured"
         return "Collection value"
-    
+
     return "Not configured"

--- a/src/IntuneCD/intunecdlib/documentation_functions.py
+++ b/src/IntuneCD/intunecdlib/documentation_functions.py
@@ -184,7 +184,12 @@ def decode_base64(data):
     """
 
     try:
-        return base64.b64decode(data).decode("utf-8")
+        decoded_data = base64.b64decode(data).decode("utf-8")
+        return (
+            f"<details>\n\n"
+            f"```text\n{decoded_data}\n```\n\n"
+            f"</details>"
+        )
     except (base64.binascii.Error, UnicodeDecodeError):
         raise ValueError("Unable to decode data")
 
@@ -196,6 +201,7 @@ def _format_value_for_markdown(value):
     :param value: The setting value to format
     :return: Formatted value string
     """
+
     if not value or value == "Not configured":
         return value
 

--- a/src/IntuneCD/intunecdlib/documentation_functions.py
+++ b/src/IntuneCD/intunecdlib/documentation_functions.py
@@ -188,17 +188,17 @@ def _format_value_for_markdown(value):
 
     value_str = str(value)
     # Check if this looks like XML content
-    if value_str.strip().startswith('```xml') and value_str.strip().endswith('```'):
+    if value_str.strip().startswith('<') and value_str.strip().endswith('>'):
         # Use the first line as summary (up to first newline or 80 chars)
         summary_line = value_str.strip().splitlines()[0] if value_str.strip().splitlines() else value_str.strip()[:80]
         summary = summary_line if len(summary_line) < 80 else summary_line[:77] + '...'
         return (
-            f"<td class='property-column2'><details class='description'><summary data-open='Minimize' data-close='{summary}...expand'></summary>\n\n"
+            f"<details class='description'><summary data-open='Minimize' data-close='{summary}...expand'></summary>\n\n"
             f"```xml\n{value_str.strip()}\n```\n\n"
-            f"</details></td>"
+            f"</details>"
         )
     # JSON pretty print (optional, keep as is)
-    if (value_str.strip().startswith('{') and value_str.strip().endswith('}')) or \
+    elif (value_str.strip().startswith('{') and value_str.strip().endswith('}')) or \
        (value_str.strip().startswith('[') and value_str.strip().endswith(']')):
         try:
             import json
@@ -207,8 +207,14 @@ def _format_value_for_markdown(value):
             return f"```json\n{formatted_json}\n```"
         except Exception:
             pass
-    if len(value_str) > 100:
-        return f"```\n{value_str}\n```"
+    elif len(value_str) > 100:
+        summary_line = value_str.strip().splitlines()[0] if value_str.strip().splitlines() else value_str.strip()[:80]
+        summary = summary_line if len(summary_line) < 80 else summary_line[:77] + '...'
+        return (
+            f"<td class='property-column2'><details class='description'><summary data-open='Minimize' data-close='{summary}...expand'></summary>\n\n"
+            f"```\n{value_str.strip()}\n```\n\n"
+            f"</details></td>"
+        )
     return value_str
 
 
@@ -293,7 +299,7 @@ def clean_list(data, decode):
         if decode and is_base64(s):
             s = decode_base64(s)
         s = _format_value_for_markdown(s)
-        if isinstance(s, str) and len(s) > 200 and not s.startswith('<details'):
+        if  len(s) > 200 and not s.startswith('<details'):
             string = f"<details><summary>Click to expand...</summary>{s}</details>"
         else:
             string = s

--- a/src/IntuneCD/intunecdlib/documentation_functions.py
+++ b/src/IntuneCD/intunecdlib/documentation_functions.py
@@ -540,6 +540,8 @@ def document_management_intents(configpath, outpath, header, split):
                 elif filename.endswith(".json"):
                     f = open(filename, encoding="utf-8")
                     repo_data = json.load(f)
+                else:
+                    continue
 
                 # Create assignments table
                 assignments_table = ""

--- a/src/IntuneCD/intunecdlib/documentation_functions.py
+++ b/src/IntuneCD/intunecdlib/documentation_functions.py
@@ -935,6 +935,13 @@ def _create_settings_tables(settings):
         if isinstance(description, str):
             description = re.sub(r'((\r\n|\r|\n){2,})', r'\r\n', description)
             description = description.rstrip(' \t')
+            # If description is too long, show summary and details
+            if len(description) > 180:
+                summary = description[:180].replace('\r', ' ').replace('\n', ' ') + "...expand"
+                description = (
+                    f"<details><summary>{summary}</summary>"
+                    f"{description}</details>"
+                )
 
         # Handle simple value
         if "simpleSettingValue" in setting_instance:

--- a/src/IntuneCD/intunecdlib/documentation_functions.py
+++ b/src/IntuneCD/intunecdlib/documentation_functions.py
@@ -149,17 +149,13 @@ def remove_characters(string):
 
 
 def is_base64(s):
-    """Check if a string is a valid base64-encoded string"""
     try:
-        # Attempt to decode the string
         if isinstance(s, str):
-            decoded = base64.b64decode(s.encode())
+            # Test for valid base64 by decoding and re-encoding
+            return base64.b64encode(base64.b64decode(s)).decode() == s
         else:
-            decoded = base64.b64decode(s)
-        # If decoding succeeds and the decoded bytes match the original string, it's a valid base64-encoded string
-        return decoded == s.encode()
-    except (TypeError, binascii.Error):
-        # If decoding fails, it's not a valid base64-encoded string
+            return False
+    except Exception:
         return False
 
 

--- a/src/IntuneCD/intunecdlib/documentation_functions.py
+++ b/src/IntuneCD/intunecdlib/documentation_functions.py
@@ -939,6 +939,10 @@ def _create_settings_tables(settings):
         definition = parent_definitions.get(setting_definition_id) or definitions_lookup.get(setting_definition_id, {})
         display_name = definition.get("displayName", _format_setting_name(setting_definition_id))
         description = definition.get("description", "")
+        # Collapse multiple newlines to a single newline, then trim trailing spaces/tabs
+        if isinstance(description, str):
+            description = re.sub(r'((\r\n|\r|\n){2,})', r'\n', description)
+            description = description.rstrip(' \t')
 
         # Handle simple value
         if "simpleSettingValue" in setting_instance:

--- a/src/IntuneCD/intunecdlib/documentation_functions.py
+++ b/src/IntuneCD/intunecdlib/documentation_functions.py
@@ -69,7 +69,7 @@ def escape_markdown(text):
     return parse
 
 
-def replace_newlines_with_br(text):
+def _replace_newlines_with_br(text):
     if isinstance(text, str):
         # Replace all \r\n, \n, or \r with <br>
         text = re.sub(r'(\r\n|\r|\n)', '<br>', text)
@@ -844,7 +844,7 @@ def _create_settings_tables(settings):
     for category in sorted_categories:
         # Add a visually distinctive row for the category
         table_rows.append([
-            f"<tr style='background-color:#e0e0e0;font-weight:bold;'><td colspan='3'>{category}</td></tr>"
+            f"<tr style='font-weight:bold;'><td colspan='3'>{category}</td></tr>"
         ])
         # Add all settings for this category
         table_rows.extend(category_map[category])
@@ -862,7 +862,7 @@ def _create_settings_tables(settings):
                 # Raw HTML row (category header)
                 table += row[0] if isinstance(row, list) else row
             else:
-                table += "<tr>" + "".join(f"<td>{cell}</td>" for cell in row) + "</tr>\n"
+                table += "<tr>" + "".join(f"<td>{_replace_newlines_with_br(cell)}</td>" for cell in row) + "</tr>\n"
         table += "</tbody>\n</table>"
         return table
 

--- a/src/IntuneCD/intunecdlib/documentation_functions.py
+++ b/src/IntuneCD/intunecdlib/documentation_functions.py
@@ -896,7 +896,7 @@ def _extract_setting_rows_for_category(setting_instance, parent_definitions, def
                     if val != "":
                         values.append(str(val))
                 if values:
-                    formatted_value = _format_value_for_markdown(f"\n```\n" + "\n".join(values) + "\n```\n")
+                    formatted_value = _format_value_for_markdown(f"\n\n```" + "\n".join(values) + "\n```\n")
                 else:
                     formatted_value = _format_value_for_markdown("Not configured")
                 return [[display_name, formatted_value, description]]

--- a/src/IntuneCD/intunecdlib/documentation_functions.py
+++ b/src/IntuneCD/intunecdlib/documentation_functions.py
@@ -69,6 +69,13 @@ def escape_markdown(text):
     return parse
 
 
+def _replace_newlines_with_br(text):
+    if isinstance(text, str):
+        # Replace all \r\n, \n, or \r with <br>
+        text = re.sub(r'(\r\n|\r|\n)', '<br>', text)
+    return text
+
+
 def assignment_table(data):
     """
     This function creates the HTML assignments table.
@@ -837,7 +844,7 @@ def _create_settings_tables(settings):
     for category in sorted_categories:
         # Add a visually distinctive row for the category
         table_rows.append([
-            f"<tr style='background-color:#e0e0e0;font-weight:bold;'><td colspan='3'>{category}</td></tr>"
+            f"<tr style='font-weight:bold;'><td colspan='3'>{category}</td></tr>"
         ])
         # Add all settings for this category
         table_rows.extend(category_map[category])
@@ -855,7 +862,7 @@ def _create_settings_tables(settings):
                 # Raw HTML row (category header)
                 table += row[0] if isinstance(row, list) else row
             else:
-                table += "<tr>" + "".join(f"<td>{cell}</td>" for cell in row) + "</tr>\n"
+                table += "<tr>" + "".join(f"<td>{_replace_newlines_with_br(cell)}</td>" for cell in row) + "</tr>\n"
         table += "</tbody>\n</table>"
         return table
 

--- a/src/IntuneCD/intunecdlib/documentation_functions.py
+++ b/src/IntuneCD/intunecdlib/documentation_functions.py
@@ -294,7 +294,7 @@ def clean_list(data, decode):
             s = decode_base64(s)
         s = _format_value_for_markdown(s)
         if  len(s) > 200 and not s.startswith('<details'):
-            string = f"<details><summary>Click to expand...</summary>{s}</details>"
+            string = f"<details>{s}</details>"
         else:
             string = s
 
@@ -883,8 +883,7 @@ def _extract_setting_rows_for_category(setting_instance, parent_definitions, def
             description = description.rstrip(' \t')
             if len(description) > 60:
                 description = (
-                    f"<details><summary>...expand...</summary>"
-                    f"{description}</details>"
+                    f"<details>{description}\n</details>"
                 )
 
         if "simpleSettingValue" in setting_instance:

--- a/src/IntuneCD/intunecdlib/documentation_functions.py
+++ b/src/IntuneCD/intunecdlib/documentation_functions.py
@@ -26,10 +26,10 @@ def html_table(headers, rows):
     table = "<table>\n<thead><tr>"
     for h in headers:
         table += f"<th>{h}</th>"
-    table += "</tr></thead>\n<tbody>\n"
+    table += "</tr></thead><tbody>"
     for row in rows:
-        table += "<tr>" + "".join(f"<td>{cell}</td>" for cell in row) + "</tr>\n"
-    table += "</tbody>\n</table>"
+        table += "<tr>" + "".join(f"<td>{cell}</td>" for cell in row) + "</tr>"
+    table += "</tbody>\n</table>\n\n"
     return table
 
 
@@ -448,7 +448,7 @@ def document_configs(
                     md.write(f"Description: {escape_markdown(description)}\n")
                 if assignments_table:
                     md.write("#### Assignments\n")
-                    md.write(str(assignments_table) + "\n")
+                    md.write(str(assignments_table) + "\n\n")
                 md.write("#### Configuration\n")
                 md.write(str(config_table) + "\n")
 
@@ -564,7 +564,7 @@ def document_management_intents(configpath, outpath, header, split):
                         md.write(f"Description: {escape_markdown(description)} \n")
                     if assignments_table:
                         md.write("#### Assignments \n")
-                        md.write(str(assignments_table) + "\n")
+                        md.write(str(assignments_table) + "\n\n")
                     md.write("#### Configuration \n")
                     md.write(str(config_table) + "\n")
 

--- a/src/IntuneCD/intunecdlib/documentation_functions.py
+++ b/src/IntuneCD/intunecdlib/documentation_functions.py
@@ -14,7 +14,23 @@ import platform
 import re
 
 import yaml
-from pytablewriter import MarkdownTableWriter
+
+
+def html_table(headers, rows):
+    """
+    Generate an HTML table from headers and rows.
+    :param headers: List of column headers
+    :param rows: List of row lists
+    :return: HTML table as a string
+    """
+    table = "<table>\n<thead><tr>"
+    for h in headers:
+        table += f"<th>{h}</th>"
+    table += "</tr></thead>\n<tbody>\n"
+    for row in rows:
+        table += "<tr>" + "".join(f"<td>{cell}</td>" for cell in row) + "</tr>\n"
+    table += "</tbody>\n</table>"
+    return table
 
 
 def md_file(outpath):
@@ -31,18 +47,12 @@ def md_file(outpath):
 
 def write_table(data):
     """
-    This function creates the markdown table.
+    This function creates the HTML table.
 
     :param data: The data to be written to the table
-    :return: The Markdown table writer
+    :return: The HTML table as a string
     """
-
-    writer = MarkdownTableWriter(
-        headers=["setting", "value"],
-        value_matrix=data,
-    )
-
-    return writer
+    return html_table(["setting", "value"], data)
 
 
 def escape_markdown(text):
@@ -61,16 +71,14 @@ def escape_markdown(text):
 
 def assignment_table(data):
     """
-    This function creates the Markdown assignments table.
+    This function creates the HTML assignments table.
 
     :param data: The data to be written to the table
-    :return: The Markdown table writer
+    :return: The HTML table as a string
     """
 
     def write_assignment_table(data, headers):
-        writer = MarkdownTableWriter(headers=headers, value_matrix=data)
-
-        return writer
+        return html_table(headers, data)
 
     table = ""
     if "assignments" in data:
@@ -910,31 +918,14 @@ def _create_settings_tables(settings):
 
 def _write_clean_table(headers, data):
     """
-    Create a clean, compact markdown table without excessive formatting.
-    
+    Create a clean, compact HTML table.
     :param headers: List of column headers
     :param data: List of rows, each row is a list of values
-    :return: Clean markdown table string
+    :return: Clean HTML table string
     """
     if not data:
         return ""
-    
-    # Create header row
-    header_row = "| " + " | ".join(headers) + " |"
-    
-    # Create separator row with simple dashes
-    separator_row = "| " + " | ".join(["---"] * len(headers)) + " |"
-    
-    # Create data rows
-    data_rows = []
-    for row in data:
-        # Ensure row has same number of columns as headers
-        padded_row = row + [""] * (len(headers) - len(row))
-        data_rows.append("| " + " | ".join(str(cell) for cell in padded_row) + " |")
-    
-    # Combine all parts
-    table_lines = [header_row, separator_row] + data_rows
-    return "\n".join(table_lines)
+    return html_table(headers, data)
 
 
 def _format_value_for_markdown(value):

--- a/src/IntuneCD/intunecdlib/documentation_functions.py
+++ b/src/IntuneCD/intunecdlib/documentation_functions.py
@@ -188,7 +188,7 @@ def _format_value_for_markdown(value):
 
     value_str = str(value)
     # Check if this looks like XML content
-    if value_str.strip().startswith('<') and value_str.strip().endswith('>'):
+    if value_str.strip().startswith('```xml') and value_str.strip().endswith('```'):
         # Use the first line as summary (up to first newline or 80 chars)
         summary_line = value_str.strip().splitlines()[0] if value_str.strip().splitlines() else value_str.strip()[:80]
         summary = summary_line if len(summary_line) < 80 else summary_line[:77] + '...'

--- a/src/IntuneCD/intunecdlib/documentation_functions.py
+++ b/src/IntuneCD/intunecdlib/documentation_functions.py
@@ -69,13 +69,6 @@ def escape_markdown(text):
     return parse
 
 
-def _replace_newlines_with_br(text):
-    if isinstance(text, str):
-        # Replace all \r\n, \n, or \r with <br>
-        text = re.sub(r'(\r\n|\r|\n)', '<br>', text)
-    return text
-
-
 def assignment_table(data):
     """
     This function creates the HTML assignments table.
@@ -862,7 +855,7 @@ def _create_settings_tables(settings):
                 # Raw HTML row (category header)
                 table += row[0] if isinstance(row, list) else row
             else:
-                table += "<tr>" + "".join(f"<td>{_replace_newlines_with_br(cell)}</td>" for cell in row) + "</tr>\n"
+                table += "<tr>" + "".join(f"<td>{cell}</td>" for cell in row) + "</tr>\n"
         table += "</tbody>\n</table>"
         return table
 

--- a/src/IntuneCD/intunecdlib/documentation_functions.py
+++ b/src/IntuneCD/intunecdlib/documentation_functions.py
@@ -149,17 +149,30 @@ def remove_characters(string):
 
 
 def is_base64(s):
-    """Check if a string is a valid base64-encoded string"""
+    """
+    Validates if a string is properly base64-encoded.
+    Combines regex pattern check and decode verification.
+
+    :param s: Input string
+    :return: True if valid base64, False otherwise
+    """
+    if not isinstance(s, str):
+        return False
+
+    s = s.strip()
+
+    # Regex to match base64 pattern (includes optional padding)
+    base64_regex = re.compile(r'^(?:[A-Za-z0-9+/]{4})*' +
+                              r'(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$')
+
+    if not base64_regex.fullmatch(s):
+        return False
+
     try:
-        # Attempt to decode the string
-        if isinstance(s, str):
-            decoded = base64.b64decode(s.encode())
-        else:
-            decoded = base64.b64decode(s)
-        # If decoding succeeds and the decoded bytes match the original string, it's a valid base64-encoded string
-        return decoded == s.encode()
-    except (TypeError, binascii.Error):
-        # If decoding fails, it's not a valid base64-encoded string
+        # Try decoding with base64 to ensure it's valid
+        base64.b64decode(s, validate=True)
+        return True
+    except (binascii.Error, ValueError):
         return False
 
 

--- a/src/IntuneCD/intunecdlib/documentation_functions.py
+++ b/src/IntuneCD/intunecdlib/documentation_functions.py
@@ -207,14 +207,6 @@ def _format_value_for_markdown(value):
             return f"```json\n{formatted_json}\n```"
         except Exception:
             pass
-    elif len(value_str) > 100:
-        summary_line = value_str.strip().splitlines()[0] if value_str.strip().splitlines() else value_str.strip()[:80]
-        summary = summary_line if len(summary_line) < 80 else summary_line[:77] + '...'
-        return (
-            f"<details class='description'><summary data-open='Minimize' data-close='{summary}...expand'></summary>\n\n"
-            f"```\n{value_str.strip()}\n```\n\n"
-            f"</details>"
-        )
     return value_str
 
 

--- a/src/IntuneCD/intunecdlib/documentation_functions.py
+++ b/src/IntuneCD/intunecdlib/documentation_functions.py
@@ -896,7 +896,7 @@ def _extract_setting_rows_for_category(setting_instance, parent_definitions, def
                     if val != "":
                         values.append(str(val))
                 if values:
-                    formatted_value = _format_value_for_markdown(f"\n\n```" + "\n".join(values) + "\n```\n")
+                    formatted_value = _format_value_for_markdown(f"\n\n```\n" + "\n".join(values) + "\n```\n")
                 else:
                     formatted_value = _format_value_for_markdown("Not configured")
                 return [[display_name, formatted_value, description]]

--- a/src/IntuneCD/intunecdlib/documentation_functions.py
+++ b/src/IntuneCD/intunecdlib/documentation_functions.py
@@ -950,6 +950,20 @@ def _create_settings_tables(settings):
             formatted_value = _format_value_for_markdown(value if value != "" else "Not configured")
             return [[display_name, formatted_value, description]]
 
+        # Handle simple setting collection value
+        elif "simpleSettingCollectionValue" in setting_instance:
+            collection = setting_instance["simpleSettingCollectionValue"]
+            if isinstance(collection, list) and collection:
+                values = []
+                for item in collection:
+                    val = item.get("value", "")
+                    if val != "":
+                        values.append(str(val))
+                formatted_value = _format_value_for_markdown("\n".join(values) if values else "Not configured")
+                return [[display_name, formatted_value, description]]
+            else:
+                return [[display_name, "Not configured", description]]
+
         # Handle choice value (with possible children)
         elif "choiceSettingValue" in setting_instance:
             choice_value_obj = setting_instance["choiceSettingValue"]

--- a/src/IntuneCD/intunecdlib/documentation_functions.py
+++ b/src/IntuneCD/intunecdlib/documentation_functions.py
@@ -415,161 +415,6 @@ def document_configs(
             print(f"[DEBUG] Error processing {filename}: {type(e).__name__}: {e}")
 
 
-def _process_settings_catalog_settings(settings_list: list) -> list:
-    """
-    Process Settings Catalog settings to extract readable setting names and values.
-    This function handles the Settings Catalog specific data structure which differs
-    from Management Intents, providing human-readable setting names and formatted values.
-    
-    :param settings_list: List of settings from Settings Catalog policy
-    :return: List of [setting_name, value] pairs for documentation table
-    """
-    settings_table_data = []
-    
-    if not settings_list:
-        return settings_table_data
-    
-    for setting in settings_list:
-        setting_name = ""
-        setting_value = ""
-        
-        # Check if setting has enriched definitions (from backup enrichment)
-        if "settingDefinitions" in setting:
-            for definition in setting["settingDefinitions"]:
-                # Use displayName if available from enriched data, otherwise fall back to ID manipulation
-                if "displayName" in definition and definition["displayName"]:
-                    setting_name = definition["displayName"]
-                else:
-                    # Fall back to processing the ID like Management Intents
-                    setting_id = definition.get("id", "")
-                    setting_name = _format_setting_name_from_id(setting_id)
-                    
-                # Add description if available from enriched data
-                description = definition.get("description", "")
-                if description:
-                    setting_name += f"<br /><em>{description}</em>"
-                    
-                break  # Only process first definition for now
-        else:
-            # Fallback: extract settingDefinitionId from settingInstance
-            if "settingInstance" in setting:
-                setting_instance = setting["settingInstance"]
-                if "settingDefinitionId" in setting_instance:
-                    setting_id = setting_instance["settingDefinitionId"]
-                    setting_name = _format_setting_name_from_id(setting_id)
-        
-        # Extract setting value
-        if "settingInstance" in setting:
-            setting_instance = setting["settingInstance"]
-            
-            # Handle different setting value types
-            if "simpleSettingValue" in setting_instance:
-                simple_value = setting_instance["simpleSettingValue"]
-                if "value" in simple_value:
-                    setting_value = str(simple_value["value"])
-            elif "choiceSettingValue" in setting_instance:
-                choice_value = setting_instance["choiceSettingValue"]
-                if "value" in choice_value:
-                    setting_value = str(choice_value["value"])
-                # Also show child settings if they exist
-                if "children" in choice_value:
-                    child_values = []
-                    for child in choice_value["children"]:
-                        child_settings = _process_settings_catalog_settings([child])
-                        child_values.extend([f"  {name}: {val}" for name, val in child_settings])
-                    if child_values:
-                        setting_value += "<br />Children:<br />" + "<br />".join(child_values)
-            elif "groupSettingCollectionValue" in setting_instance:
-                collection_value = setting_instance["groupSettingCollectionValue"]
-                if "value" in collection_value:
-                    collection_items = []
-                    for item in collection_value["value"]:
-                        if "children" in item:
-                            item_settings = _process_settings_catalog_settings(item["children"])
-                            item_str = "<br />".join([f"  {name}: {val}" for name, val in item_settings])
-                            collection_items.append(item_str)
-                    setting_value = "<br />".join(collection_items)
-                
-            # Format complex values for better readability
-            if isinstance(setting_value, str) and len(setting_value.split(",")) > 1:
-                vals = []
-                for v in setting_value.split(","):
-                    v = v.strip()
-                    if ":" in v:
-                        v = f'**{v.replace(":", ":** ")}'
-                    vals.append(v)
-                setting_value = "<br />".join(vals)
-        
-        # Only add to table if we have both name and value
-        if setting_name and setting_value:
-            settings_table_data.append([setting_name, setting_value])
-    
-    return settings_table_data
-
-
-def _format_setting_name_from_id(setting_id: str) -> str:
-    """
-    Format a setting name from a setting definition ID by converting it to readable format.
-    
-    :param setting_id: The setting definition ID
-    :return: Formatted readable setting name
-    """
-    if not setting_id:
-        return ""
-        
-    # For Settings Catalog IDs, extract meaningful part by looking for common patterns
-    if "device_vendor_msft_policy_config_" in setting_id:
-        # Remove the common prefix to get the actual setting name
-        parts = setting_id.replace("device_vendor_msft_policy_config_", "").split("_")
-        # Take the last 2-3 parts for better context, avoiding very generic terms
-        if len(parts) >= 2:
-            # Look for meaningful parts, excluding generic ones
-            meaningful_parts = []
-            for part in parts:
-                if part and part.lower() not in ['config', 'policy', 'device', 'vendor', 'msft']:
-                    meaningful_parts.append(part)
-            # Take the last 2 meaningful parts for better readability
-            if len(meaningful_parts) >= 2:
-                setting_name = "_".join(meaningful_parts[-2:])
-            elif meaningful_parts:
-                setting_name = meaningful_parts[-1]
-            else:
-                setting_name = parts[-1] if parts else setting_id
-        else:
-            setting_name = parts[-1] if parts else setting_id
-    else:
-        # For other types of IDs, take the last part after underscore
-        if "_" in setting_id:
-            setting_name = setting_id.split("_")[-1]
-        else:
-            setting_name = setting_id
-        
-    # Convert camelCase/PascalCase to readable format
-    if setting_name:
-        # Handle underscore-separated words first
-        if "_" in setting_name:
-            words = setting_name.split("_")
-            formatted_words = []
-            for word in words:
-                if word:
-                    # Capitalize first letter and handle camelCase within the word
-                    word = word[0].upper() + word[1:] if word else ""
-                    camel_parts = re.findall("[A-Z][^A-Z]*", word)
-                    if camel_parts:
-                        formatted_words.extend(camel_parts)
-                    else:
-                        formatted_words.append(word)
-            setting_name = " ".join(formatted_words)
-        else:
-            # Handle pure camelCase/PascalCase
-            setting_name = setting_name[0].upper() + setting_name[1:] if setting_name else ""
-            camel_parts = re.findall("[A-Z][^A-Z]*", setting_name)
-            if camel_parts:
-                setting_name = " ".join(camel_parts)
-    
-    return setting_name
-
-
 def document_management_intents(configpath, outpath, header, split):
     """
     This function documents the management intents.
@@ -615,36 +460,28 @@ def document_management_intents(configpath, outpath, header, split):
                 repo_data.pop("assignments", None)
 
                 intent_settings_list = []
-                
-                # Handle Management Intents with settingsDelta (existing logic)
-                if "settingsDelta" in repo_data:
-                    for setting in repo_data["settingsDelta"]:
-                        setting_definition = setting["definitionId"].split("_")[1]
-                        setting_definition = (
-                            setting_definition[0].upper() + setting_definition[1:]
-                        )
-                        setting_definition = re.findall("[A-Z][^A-Z]*", setting_definition)
-                        setting_definition = " ".join(setting_definition)
+                for setting in repo_data["settingsDelta"]:
+                    setting_definition = setting["definitionId"].split("_")[1]
+                    setting_definition = (
+                        setting_definition[0].upper() + setting_definition[1:]
+                    )
+                    setting_definition = re.findall("[A-Z][^A-Z]*", setting_definition)
+                    setting_definition = " ".join(setting_definition)
 
-                        vals = []
-                        value = str(remove_characters(setting["valueJson"]))
-                        comma = re.findall("[:][^:]*", value)
-                        for v in value.split(","):
-                            v = v.replace(" ", "")
-                            if comma:
-                                v = f'**{v.replace(":", ":** ")}'
-                            vals.append(v)
-                        value = ",".join(vals)
-                        value = value.replace(",", "<br />")
+                    vals = []
+                    value = str(remove_characters(setting["valueJson"]))
+                    comma = re.findall("[:][^:]*", value)
+                    for v in value.split(","):
+                        v = v.replace(" ", "")
+                        if comma:
+                            v = f'**{v.replace(":", ":** ")}'
+                        vals.append(v)
+                    value = ",".join(vals)
+                    value = value.replace(",", "<br />")
 
-                        intent_settings_list.append([setting_definition, value])
+                    intent_settings_list.append([setting_definition, value])
 
-                    repo_data.pop("settingsDelta")
-                
-                # Handle Settings Catalog with settings array (new logic for readable documentation)
-                elif "settings" in repo_data:
-                    intent_settings_list = _process_settings_catalog_settings(repo_data["settings"])
-                    repo_data.pop("settings")
+                repo_data.pop("settingsDelta")
 
                 description = ""
                 if "description" in repo_data:

--- a/src/IntuneCD/intunecdlib/documentation_functions.py
+++ b/src/IntuneCD/intunecdlib/documentation_functions.py
@@ -69,6 +69,13 @@ def escape_markdown(text):
     return parse
 
 
+def replace_newlines_with_br(text):
+    if isinstance(text, str):
+        # Replace all \r\n, \n, or \r with <br>
+        text = re.sub(r'(\r\n|\r|\n)', '<br>', text)
+    return text
+
+
 def assignment_table(data):
     """
     This function creates the HTML assignments table.

--- a/src/IntuneCD/intunecdlib/documentation_functions.py
+++ b/src/IntuneCD/intunecdlib/documentation_functions.py
@@ -211,9 +211,9 @@ def _format_value_for_markdown(value):
         summary_line = value_str.strip().splitlines()[0] if value_str.strip().splitlines() else value_str.strip()[:80]
         summary = summary_line if len(summary_line) < 80 else summary_line[:77] + '...'
         return (
-            f"<td class='property-column2'><details class='description'><summary data-open='Minimize' data-close='{summary}...expand'></summary>\n\n"
+            f"<details class='description'><summary data-open='Minimize' data-close='{summary}...expand'></summary>\n\n"
             f"```\n{value_str.strip()}\n```\n\n"
-            f"</details></td>"
+            f"</details>"
         )
     return value_str
 
@@ -970,43 +970,6 @@ def _write_clean_table(headers, data):
     if not data:
         return ""
     return html_table(headers, data)
-
-
-def _format_value_for_markdown(value):
-    """
-    Format setting value for markdown display, handling XML/JSON structures.
-
-    :param value: The setting value to format
-    :return: Formatted value string
-    """
-    if not value or value == "Not configured":
-        return value
-
-    value_str = str(value)
-
-    # Check if this looks like XML content
-    if value_str.strip().startswith('<') and value_str.strip().endswith('>'):
-        # Format as XML code block
-        return f"```xml\n{value_str.strip()}\n```"
-
-    # Check if this looks like JSON content
-    if (value_str.strip().startswith('{') and value_str.strip().endswith('}')) or \
-       (value_str.strip().startswith('[') and value_str.strip().endswith(']')):
-        try:
-            import json
-            # Try to parse and pretty-format JSON
-            parsed = json.loads(value_str)
-            formatted_json = json.dumps(parsed, indent=2)
-            return f"```json\n{formatted_json}\n```"
-        except Exception:
-            # If parsing fails, treat as regular text
-            pass
-
-    # For very long values (> 100 chars), use code block
-    if len(value_str) > 100:
-        return f"```\n{value_str}\n```"
-
-    return value_str
 
 
 def _extract_category_from_id(setting_definition_id):

--- a/src/IntuneCD/intunecdlib/documentation_functions.py
+++ b/src/IntuneCD/intunecdlib/documentation_functions.py
@@ -895,7 +895,7 @@ def _extract_setting_rows_for_category(setting_instance, parent_definitions, def
                     val = item.get("value", "")
                     if val != "":
                         values.append(str(val))
-                formatted_value = _format_value_for_markdown("\n".join(values) if values else "Not configured")
+                formatted_value = _format_value_for_markdown("\n\n```\n".join(values).join("\n```\n\n") if values else "Not configured")
                 return [[display_name, formatted_value, description]]
             else:
                 return [[display_name, "Not configured", description]]

--- a/src/IntuneCD/intunecdlib/documentation_functions.py
+++ b/src/IntuneCD/intunecdlib/documentation_functions.py
@@ -895,7 +895,10 @@ def _extract_setting_rows_for_category(setting_instance, parent_definitions, def
                     val = item.get("value", "")
                     if val != "":
                         values.append(str(val))
-                formatted_value = _format_value_for_markdown("\n\n```\n".join(values).join("\n```\n\n") if values else "Not configured")
+                if values:
+                    formatted_value = _format_value_for_markdown(f"\n```\n" + "\n".join(values) + "\n```\n")
+                else:
+                    formatted_value = _format_value_for_markdown("Not configured")
                 return [[display_name, formatted_value, description]]
             else:
                 return [[display_name, "Not configured", description]]

--- a/src/IntuneCD/intunecdlib/documentation_functions.py
+++ b/src/IntuneCD/intunecdlib/documentation_functions.py
@@ -189,12 +189,9 @@ def _format_value_for_markdown(value):
     value_str = str(value)
     # Check if this looks like XML content
     if value_str.strip().startswith('<') and value_str.strip().endswith('>'):
-        # Use the first line as summary (up to first newline or 80 chars)
-        summary_line = value_str.strip().splitlines()[0] if value_str.strip().splitlines() else value_str.strip()[:80]
-        summary = summary_line if len(summary_line) < 80 else summary_line[:77] + '...'
         return (
-            f"<details class='description'><summary data-open='Minimize' data-close='{summary}...expand'></summary>\n\n"
-            f"```xml\n{value_str.strip()}\n```\n\n"
+            f"<details class='description'><summary data-open='Minimize' data-close='...expand...'></summary>"
+            f"```xml\n{value_str.strip()}\n```"
             f"</details>"
         )
     # JSON pretty print (optional, keep as is)
@@ -936,10 +933,9 @@ def _create_settings_tables(settings):
             description = re.sub(r'((\r\n|\r|\n){2,})', r'\r\n', description)
             description = description.rstrip(' \t')
             # If description is too long, show summary and details
-            if len(description) > 180:
-                summary = description[:180].replace('\r', ' ').replace('\n', ' ') + "...expand"
+            if len(description) > 60:
                 description = (
-                    f"<details><summary>{summary}</summary>"
+                    f"<details><summary>...expand...</summary>"
                     f"{description}</details>"
                 )
 

--- a/src/IntuneCD/intunecdlib/documentation_functions.py
+++ b/src/IntuneCD/intunecdlib/documentation_functions.py
@@ -941,7 +941,7 @@ def _create_settings_tables(settings):
         description = definition.get("description", "")
         # Collapse multiple newlines to a single newline, then trim trailing spaces/tabs
         if isinstance(description, str):
-            description = re.sub(r'((\r\n|\r|\n){2,})', r'\n', description)
+            description = re.sub(r'((\r\n|\r|\n){2,})', r'\r\n', description)
             description = description.rstrip(' \t')
 
         # Handle simple value

--- a/src/IntuneCD/intunecdlib/documentation_functions.py
+++ b/src/IntuneCD/intunecdlib/documentation_functions.py
@@ -149,13 +149,17 @@ def remove_characters(string):
 
 
 def is_base64(s):
+    """Check if a string is a valid base64-encoded string"""
     try:
+        # Attempt to decode the string
         if isinstance(s, str):
-            # Test for valid base64 by decoding and re-encoding
-            return base64.b64encode(base64.b64decode(s)).decode() == s
+            decoded = base64.b64decode(s.encode())
         else:
-            return False
-    except Exception:
+            decoded = base64.b64decode(s)
+        # If decoding succeeds and the decoded bytes match the original string, it's a valid base64-encoded string
+        return decoded == s.encode()
+    except (TypeError, binascii.Error):
+        # If decoding fails, it's not a valid base64-encoded string
         return False
 
 

--- a/src/IntuneCD/intunecdlib/documentation_functions.py
+++ b/src/IntuneCD/intunecdlib/documentation_functions.py
@@ -178,33 +178,104 @@ def decode_base64(data):
 
 def _format_value_for_markdown(value):
     """
-    Format setting value for markdown display, handling XML/JSON structures.
-    If XML, wrap in <details> block with summary and code block.
+    Format setting value for markdown display, handling XML/JSON structures (nested in text or by itself), handling decoded base64 strings, handling long values and ensuring it is suitable for display in a Markdown document.
+    Wrap in <details> block with code block, or return as plain text if not structured.
     :param value: The setting value to format
     :return: Formatted value string
     """
     if not value or value == "Not configured":
         return value
 
-    value_str = str(value)
-    # Check if this looks like XML content
+    return_str = ""
+    raw_str = str(value)
+
+    # If the value contains XML or JSON, wrap it in a <details> code block
+    if ("<" in raw_str and ">" in raw_str) or \
+       ("{" in raw_str and "}" in raw_str) or \
+       ("[" in raw_str and "]" in raw_str):
+
+        value_str = ""  # Initialize value_str to avoid UnboundLocalError
+        after_str = ""  # Initialize after_str to avoid UnboundLocalError
+
+        # Find first and last positions for < > { } [ ]
+        firsts = {
+            "xml": raw_str.find("<"),
+            "json_obj": raw_str.find("{"),
+            "json_arr": raw_str.find("["),
+        }
+        lasts = {
+            "xml": raw_str.rfind(">"),
+            "json_obj": raw_str.rfind("}"),
+            "json_arr": raw_str.rfind("]"),
+        }
+        # Only consider if both first and last are found and in correct order
+        candidates = []
+        for typ in ["xml", "json_obj", "json_arr"]:
+            if firsts[typ] != -1 and lasts[typ] != -1 and firsts[typ] < lasts[typ]:
+                candidates.append((firsts[typ], lasts[typ], typ))
+        if candidates:
+            # Pick the type with the earliest first and latest last
+            selected = min(candidates, key=lambda x: (x[0], -x[1]))
+            first, last, typ = selected
+            return_str += raw_str[:first]
+            value_str = raw_str[first:last+1]
+            after_str = raw_str[last+1:]
+
+    if not value_str:
+        value_str = raw_str
+
+    # Handle XML
     if value_str.strip().startswith('<') and value_str.strip().endswith('>'):
-        return (
-            f"<details class='description'><summary data-open='Minimize' data-close='...expand...'></summary>\n\n"
+        return_str += (
+            f"<details>\n\n"
             f"```xml\n{value_str.strip()}\n```\n\n"
             f"</details>"
         )
-    # JSON pretty print (optional, keep as is)
+    # Handle JSON pretty print
     elif (value_str.strip().startswith('{') and value_str.strip().endswith('}')) or \
        (value_str.strip().startswith('[') and value_str.strip().endswith(']')):
         try:
             import json
             parsed = json.loads(value_str)
             formatted_json = json.dumps(parsed, indent=2)
-            return f"\n\n```json\n{formatted_json}\n```\n\n"
+            return_str += (
+                f"<details>\n\n"
+                f"```json\n{formatted_json}\n```\n\n"
+                f"</details>"
+            )
         except Exception:
-            pass
-    return value_str
+            return_str += (
+                f"<details>\n\n"
+                f"```text\n{value_str.str}\n```\n\n"
+                f"</details>"
+            )
+    # Handle base64 encoded strings
+    elif is_base64(value_str):
+        try:
+            decoded_value = decode_base64(value_str)
+            return_str += (
+                f"<details>\n\n"
+                f"```text\n{decoded_value}\n```\n\n"
+                f"</details>"
+            )
+        except ValueError:
+            return_str += escape_markdown(value_str)
+    # If it's a simple string, escape it for markdown
+    else:
+        return_str += escape_markdown(value_str)
+
+    # Rejoin the parts if they were split
+    if after_str:
+        return_str += after_str
+
+    # Handle long strings by allowing users to expand and view the content only when needed.
+    if not return_str.startswith('<details') and len(return_str) > 200:
+        return_str += (
+            f"<details>\n\n"
+            f"```text\n{value_str}\n```\n\n"
+            f"</details>"
+        )
+    return return_str
 
 
 def clean_list(data, decode):
@@ -284,17 +355,6 @@ def clean_list(data, decode):
 
         return string
 
-    def string(s) -> str:
-        if decode and is_base64(s):
-            s = decode_base64(s)
-        s = _format_value_for_markdown(s)
-        if  len(s) > 200 and not s.startswith('<details'):
-            string = f"<details><summary>Click to expand...</summary>{s}</details>"
-        else:
-            string = s
-
-        return string
-
     values = []
 
     for item in data:
@@ -303,7 +363,7 @@ def clean_list(data, decode):
         elif isinstance(item, dict):
             values.append(dict_to_ul(item))
         elif isinstance(item, str):
-            values.append(string(item))
+            values.append(_format_value_for_markdown(item))
         elif isinstance(item, (bool, int)):
             values.append(item)
         else:
@@ -855,7 +915,7 @@ def _create_settings_tables(settings):
                 # Raw HTML row (category header)
                 table += row[0] if isinstance(row, list) else row
             else:
-                table += "<tr>" + "".join(f"<td>{cell}</td>" for cell in row) + "</tr>\n"
+                table += "<tr>" + "".join(f"<td>{cell}</td>" for cell in row) + "</tr>"
         table += "</tbody>\n</table>"
         return table
 
@@ -878,13 +938,15 @@ def _extract_setting_rows_for_category(setting_instance, parent_definitions, def
             description = description.rstrip(' \t')
             if len(description) > 60:
                 description = (
-                    f"<details><summary>...expand...</summary>"
-                    f"{description}</details>"
+                    f"<details>{description}</details>"
                 )
 
         if "simpleSettingValue" in setting_instance:
             value = setting_instance["simpleSettingValue"].get("value", "")
-            formatted_value = _format_value_for_markdown(value if value != "" else "Not configured")
+            if value != "":
+                formatted_value = _format_value_for_markdown(value)
+            else:
+                formatted_value = _format_value_for_markdown("Not configured")
             return [[display_name, formatted_value, description]]
 
         elif "simpleSettingCollectionValue" in setting_instance:
@@ -896,7 +958,8 @@ def _extract_setting_rows_for_category(setting_instance, parent_definitions, def
                     if val != "":
                         values.append(str(val))
                 if values:
-                    formatted_value = _format_value_for_markdown(f"\n\n```\n" + "\n".join(values) + "\n```\n")
+                    # formatted_value = _format_value_for_markdown(f"\n\n```\n" + "\n".join(values) + "\n```\n")
+                    formatted_value = _format_value_for_markdown(values)
                 else:
                     formatted_value = _format_value_for_markdown("Not configured")
                 return [[display_name, formatted_value, description]]
@@ -913,7 +976,12 @@ def _extract_setting_rows_for_category(setting_instance, parent_definitions, def
                     if option.get("value") == value or option.get("itemId") == value:
                         option_display_name = option.get("displayName") or option.get("name")
                         break
-            formatted_value = _format_value_for_markdown(option_display_name if option_display_name else (value if value else "Not configured"))
+            if option_display_name:
+                formatted_value = _format_value_for_markdown(option_display_name)
+            elif value:
+                formatted_value = _format_value_for_markdown(value)
+            else:
+                formatted_value = _format_value_for_markdown("Not configured")
             rows = []
             rows.append([display_name, formatted_value, description])
             for child in children:

--- a/src/IntuneCD/intunecdlib/documentation_functions.py
+++ b/src/IntuneCD/intunecdlib/documentation_functions.py
@@ -951,9 +951,15 @@ def _create_settings_tables(settings):
             choice_value_obj = setting_instance["choiceSettingValue"]
             value = choice_value_obj.get("value", "")
             children = choice_value_obj.get("children", [])
+            # --- NEW LOGIC: Lookup displayName for selected option ---
+            option_display_name = None
+            if value and "options" in definition:
+                for option in definition["options"]:
+                    if option.get("value") == value or option.get("itemId") == value:
+                        option_display_name = option.get("displayName") or option.get("name")
+                        break
+            formatted_value = _format_value_for_markdown(option_display_name if option_display_name else (value if value else "Not configured"))
             rows = []
-            # Add the main choice value row
-            formatted_value = _format_value_for_markdown(value if value else "Not configured")
             rows.append([display_name, formatted_value, description])
             # Add children rows, if any
             for child in children:
@@ -988,7 +994,6 @@ def _create_settings_tables(settings):
         return [("Configuration", table)]
 
     return []
-
 
 def _write_clean_table(headers, data):
     """

--- a/src/IntuneCD/intunecdlib/documentation_functions.py
+++ b/src/IntuneCD/intunecdlib/documentation_functions.py
@@ -190,8 +190,8 @@ def _format_value_for_markdown(value):
     # Check if this looks like XML content
     if value_str.strip().startswith('<') and value_str.strip().endswith('>'):
         return (
-            f"<details class='description'><summary data-open='Minimize' data-close='...expand...'></summary>"
-            f"```xml\n{value_str.strip()}\n```"
+            f"<details class='description'><summary data-open='Minimize' data-close='...expand...'></summary>\n\n"
+            f"```xml\n{value_str.strip()}\n```\n\n"
             f"</details>"
         )
     # JSON pretty print (optional, keep as is)
@@ -201,7 +201,7 @@ def _format_value_for_markdown(value):
             import json
             parsed = json.loads(value_str)
             formatted_json = json.dumps(parsed, indent=2)
-            return f"```json\n{formatted_json}\n```"
+            return f"\n\n```json\n{formatted_json}\n```\n\n"
         except Exception:
             pass
     return value_str

--- a/tests/test_documentation_functions.py
+++ b/tests/test_documentation_functions.py
@@ -178,9 +178,10 @@ class TestDocumentationFunctions(unittest.TestCase):
 
     def test_process_settings_catalog_settings(self):
         """Test Settings Catalog settings processing for readable documentation."""
-        # Mock Settings Catalog data structure
+        # Mock Settings Catalog data structure matching real Microsoft Graph API response
         settings_data = [
             {
+                "id": "0",
                 "settingDefinitions": [
                     {
                         "id": "device_vendor_msft_policy_config_defender_allowfullscanremovabledrive",
@@ -190,6 +191,7 @@ class TestDocumentationFunctions(unittest.TestCase):
                 ],
                 "settingInstance": {
                     "@odata.type": "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance",
+                    "settingDefinitionId": "device_vendor_msft_policy_config_defender_allowfullscanremovabledrive",
                     "simpleSettingValue": {
                         "@odata.type": "#microsoft.graph.deviceManagementConfigurationStringSettingValue",
                         "value": "allowed"
@@ -197,6 +199,7 @@ class TestDocumentationFunctions(unittest.TestCase):
                 }
             },
             {
+                "id": "1", 
                 "settingDefinitions": [
                     {
                         "id": "device_vendor_msft_policy_config_defender_realTimeProtection",
@@ -206,6 +209,7 @@ class TestDocumentationFunctions(unittest.TestCase):
                 ],
                 "settingInstance": {
                     "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance", 
+                    "settingDefinitionId": "device_vendor_msft_policy_config_defender_realTimeProtection",
                     "choiceSettingValue": {
                         "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingValue",
                         "value": "device_vendor_msft_policy_config_defender_realTimeProtection_1"
@@ -234,16 +238,16 @@ class TestDocumentationFunctions(unittest.TestCase):
 
     def test_process_settings_catalog_settings_fallback(self):
         """Test Settings Catalog settings processing falls back to ID manipulation when no displayName."""
+        # Test fallback scenario: no enriched settingDefinitions, just raw settingInstance
         settings_data = [
             {
-                "settingDefinitions": [
-                    {
-                        "id": "device_vendor_msft_policy_config_defender_allowFullScan"
-                    }
-                ],
+                "id": "0",
                 "settingInstance": {
+                    "@odata.type": "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance",
+                    "settingDefinitionId": "device_vendor_msft_policy_config_localpoliciessecurityoptions_interactivelogon_machineinactivitylimit_v2",
                     "simpleSettingValue": {
-                        "value": "enabled"
+                        "@odata.type": "#microsoft.graph.deviceManagementConfigurationIntegerSettingValue",
+                        "value": 14400
                     }
                 }
             }
@@ -251,7 +255,9 @@ class TestDocumentationFunctions(unittest.TestCase):
         
         result = _process_settings_catalog_settings(settings_data)
         
-        # Should fall back to processing the ID
+        # Verify fallback processing works
         self.assertEqual(len(result), 1)
-        self.assertEqual(result[0][0], "Allow Full Scan")  # Converted from allowFullScan
-        self.assertEqual(result[0][1], "enabled")
+        # Should extract "machineinactivitylimit_v2" and format it as "Machineinactivitylimit V2"
+        expected_name = "Machineinactivitylimit V2"  # This is what the ID formatting logic should produce
+        self.assertEqual(result[0][0], expected_name)
+        self.assertEqual(result[0][1], "14400")

--- a/tests/test_documentation_functions.py
+++ b/tests/test_documentation_functions.py
@@ -14,7 +14,6 @@ from src.IntuneCD.intunecdlib.documentation_functions import (
     md_file,
     remove_characters,
     write_table,
-    _process_settings_catalog_settings,
 )
 
 
@@ -175,89 +174,3 @@ class TestDocumentationFunctions(unittest.TestCase):
         self.expected_list = ["./config/test_file_name.md"]
 
         self.assertEqual(get_md_files(self.directory.path), self.expected_list)
-
-    def test_process_settings_catalog_settings(self):
-        """Test Settings Catalog settings processing for readable documentation."""
-        # Mock Settings Catalog data structure matching real Microsoft Graph API response
-        settings_data = [
-            {
-                "id": "0",
-                "settingDefinitions": [
-                    {
-                        "id": "device_vendor_msft_policy_config_defender_allowfullscanremovabledrive",
-                        "displayName": "Allow Full Scan Removable Drive", 
-                        "description": "Allow or disallow full scan of removable drives"
-                    }
-                ],
-                "settingInstance": {
-                    "@odata.type": "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance",
-                    "settingDefinitionId": "device_vendor_msft_policy_config_defender_allowfullscanremovabledrive",
-                    "simpleSettingValue": {
-                        "@odata.type": "#microsoft.graph.deviceManagementConfigurationStringSettingValue",
-                        "value": "allowed"
-                    }
-                }
-            },
-            {
-                "id": "1", 
-                "settingDefinitions": [
-                    {
-                        "id": "device_vendor_msft_policy_config_defender_realTimeProtection",
-                        "displayName": "Real-time Protection",
-                        "description": "Enable real-time protection"
-                    }
-                ],
-                "settingInstance": {
-                    "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance", 
-                    "settingDefinitionId": "device_vendor_msft_policy_config_defender_realTimeProtection",
-                    "choiceSettingValue": {
-                        "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingValue",
-                        "value": "device_vendor_msft_policy_config_defender_realTimeProtection_1"
-                    }
-                }
-            }
-        ]
-        
-        result = _process_settings_catalog_settings(settings_data)
-        
-        # Verify the function returns readable setting names and values
-        self.assertEqual(len(result), 2)
-        
-        # First setting should use display name
-        self.assertEqual(result[0][0], "Allow Full Scan Removable Drive<br /><em>Allow or disallow full scan of removable drives</em>")
-        self.assertEqual(result[0][1], "allowed")
-        
-        # Second setting should use display name  
-        self.assertEqual(result[1][0], "Real-time Protection<br /><em>Enable real-time protection</em>")
-        self.assertEqual(result[1][1], "device_vendor_msft_policy_config_defender_realTimeProtection_1")
-
-    def test_process_settings_catalog_settings_empty(self):
-        """Test Settings Catalog settings processing with empty data."""
-        result = _process_settings_catalog_settings([])
-        self.assertEqual(result, [])
-
-    def test_process_settings_catalog_settings_fallback(self):
-        """Test Settings Catalog settings processing falls back to ID manipulation when no displayName."""
-        # Test fallback scenario: no enriched settingDefinitions, just raw settingInstance
-        settings_data = [
-            {
-                "id": "0",
-                "settingInstance": {
-                    "@odata.type": "#microsoft.graph.deviceManagementConfigurationSimpleSettingInstance",
-                    "settingDefinitionId": "device_vendor_msft_policy_config_localpoliciessecurityoptions_interactivelogon_machineinactivitylimit_v2",
-                    "simpleSettingValue": {
-                        "@odata.type": "#microsoft.graph.deviceManagementConfigurationIntegerSettingValue",
-                        "value": 14400
-                    }
-                }
-            }
-        ]
-        
-        result = _process_settings_catalog_settings(settings_data)
-        
-        # Verify fallback processing works
-        self.assertEqual(len(result), 1)
-        # Should extract "machineinactivitylimit_v2" and format it as "Machineinactivitylimit V2"
-        expected_name = "Machineinactivitylimit V2"  # This is what the ID formatting logic should produce
-        self.assertEqual(result[0][0], expected_name)
-        self.assertEqual(result[0][1], "14400")


### PR DESCRIPTION
@almenscorner here are my changes to improve readability of the generated documentation [issue242](https://github.com/almenscorner/IntuneCD/issues/242)
I've tested this and found no further bugs so far, all the documentation seems te be shown correctly.

Main improvements are:
- extended settingdefinition in JSON backup for SettingsCatalog
- used HTML tables in markdown
- translated odata.type settings to it's setting name, value and description where possible
- handled XML and JSON structures with codeblocks and foldable sections

Let me know what you think!