### PR TITLE
Improve settings catalog documentation readability

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = IntuneCD
-version = 2.4.1
+version = 2.4.2.beta1
 author = Tobias Almén
 author_email = almenscorner@outlook.com
 description = Tool to backup and update configurations in Intune

--- a/src/IntuneCD/document_intune.py
+++ b/src/IntuneCD/document_intune.py
@@ -4,6 +4,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from .intunecdlib.documentation_functions import (
     document_configs,
     document_management_intents,
+    document_settings_catalog,
 )
 from .decorators import time_command
 
@@ -66,7 +67,6 @@ def document_intune(
         ("Scripts/Shell", "Shell Scripts"),
         ("Custom Attributes", "Custom Attributes"),
         ("Scripts/Powershell", "Powershell Scripts"),
-        ("Settings Catalog", "Settings Catalog"),
         ("Driver Updates", "Windows Driver Updates"),
         ("Feature Updates", "Windows Feature Updates"),
         ("Quality Updates", "Windows Quality Updates"),
@@ -118,4 +118,9 @@ def document_intune(
     # **Run Management Intents Sequentially**
     document_management_intents(
         f"{configpath}/Management Intents/", outpath, "Management Intents", split
+    )
+    
+    # **Run Settings Catalog with specialized documentation**
+    document_settings_catalog(
+        f"{configpath}/Settings Catalog/", outpath, "Settings Catalog", split, split_per_config
     )

--- a/src/IntuneCD/intunecdlib/BaseUpdateModule.py
+++ b/src/IntuneCD/intunecdlib/BaseUpdateModule.py
@@ -102,15 +102,16 @@ class BaseUpdateModule(BaseGraphModule):
 
     def remove_non_graph_properties(self, data):
         """
-        Recursively remove properties not accepted by Graph API, such as 'categoryDisplayName' from settingDefinitions.
+        Recursively remove properties not accepted by Graph API, including the entire 'settingDefinitions' property from settings.
         """
         if isinstance(data, dict):
-            # Remove from settingDefinitions in settings
+            # Remove settingDefinitions from settings
             if "settings" in data and isinstance(data["settings"], list):
                 for setting in data["settings"]:
-                    if "settingDefinitions" in setting and isinstance(setting["settingDefinitions"], list):
-                        for definition in setting["settingDefinitions"]:
-                            definition.pop("categoryDisplayName", None)
+                    if "settingDefinitions" in setting:
+                        setting.pop("settingDefinitions", None)
+                    # Recursively clean nested dicts in settings
+                    self.remove_non_graph_properties(setting)
             # Recursively clean nested dicts
             for v in data.values():
                 self.remove_non_graph_properties(v)


### PR DESCRIPTION
Pull request related to issue: https://github.com/almenscorner/IntuneCD/issues/242
- Improve Settings Catalog documentation with readable setting names and values
- Enhanced SettingsCatalog backup to capture setting display names and descriptions
- Modified document_management_intents to handle Settings Catalog policies
- Added _process_settings_catalog_settings helper function for readable documentation
- Updated document_intune.py to process Settings Catalog with special handling
- Added inline comments explaining the improvements
- Added html table collapse for long values such as xml, json
- Added retrieval of all settingdefinitionIds for backedup settingscatalog policy
- Added RootCategory for top level settingDefinition
- Fixed bug during update process because of added non graph property to settingdefinitions during backup for documentation purposes
- Fixed bug for encoded scriptcontent is never decoded in the generated documentation (when providing the flag --decode when running IntuneCD-startdocumentation). This is caused by a bug in def is_base64: this returns true for invalid base64 strings.
    - Applied fix for is_base64: now only returns true when valid base64 string
    - Ensured the decoded scriptcontent is formatted properly (escaped as codeblock)
      
Example generated documentation (bugfix encoded scriptcontent:
![image](https://github.com/user-attachments/assets/ccd814de-7bc8-4f3c-b686-d1be7a5c8915)

Example documentation before:
![image](https://github.com/user-attachments/assets/039e09fe-1c89-4e77-9f49-d456b9a52f8f)

Example documentation after:
![image](https://github.com/user-attachments/assets/0bb444bc-b5c8-4f12-b6f9-7b8005e763ba)
