### PR TITLE
Fix proactive remediation script matching without append-id

### DIFF
--- a/src/IntuneCD/update/Intune/ProactiveRemediation.py
+++ b/src/IntuneCD/update/Intune/ProactiveRemediation.py
@@ -29,20 +29,25 @@ class ProactiveRemediationUpdateModule(BaseUpdateModule):
         self.assignment_key = "deviceHealthScriptAssignments"
 
     def _get_script_data(self, filename: str) -> tuple[str, str]:
-        fname_id = filename.split("__")
         detection_script_name = ""
         remediation_script_name = ""
-
-        if len(fname_id) > 1:
-            fname_id = fname_id[1].replace(".json", "").replace(".yaml", "")
-        else:
-            fname_id = ""
 
         # Get all remediation scripts and detection scripts files
         script_files = os.listdir(self.script_data_path)
 
-        # Filter out files that matches the id
-        script_files = [f for f in script_files if fname_id in f]
+        # Prefer the filename prefix used when backups do not append ids.
+        filename_prefix = os.path.splitext(filename)[0]
+        prefix_matches = [
+            f for f in script_files if f.startswith(f"{filename_prefix}_")
+        ]
+        if prefix_matches:
+            script_files = prefix_matches
+        else:
+            filename_parts = filename_prefix.rsplit("__", 1)
+            if len(filename_parts) > 1:
+                script_files = [f for f in script_files if filename_parts[1] in f]
+            else:
+                script_files = []
 
         # Set detection and remediation script name and path
         for f in script_files:

--- a/tests/Update/Intune/test_ProactiveRemediation.py
+++ b/tests/Update/Intune/test_ProactiveRemediation.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from src.IntuneCD.update.Intune.ProactiveRemediation import (
+    ProactiveRemediationUpdateModule,
+)
+
+
+class TestProactiveRemediationUpdateModule(unittest.TestCase):
+    """Tests for the ProactiveRemediationUpdateModule class."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.module = ProactiveRemediationUpdateModule(path=self.temp_dir.name)
+        os.makedirs(self.module.script_data_path)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def _write_script(self, filename: str, content: str) -> None:
+        with open(
+            f"{self.module.script_data_path}{filename}", "w", encoding="utf-8"
+        ) as f:
+            f.write(content)
+
+    def test_get_script_data_matches_filename_prefix_without_append_id(self):
+        """Test that scripts are matched by policy name when filenames have no id."""
+        script_files = [
+            "Policy A_detectionScript.ps1",
+            "Policy A_remediationScript.ps1",
+            "Policy A Extra_detectionScript.ps1",
+            "Policy A Extra_remediationScript.ps1",
+            "Policy B_detectionScript.ps1",
+            "Policy B_remediationScript.ps1",
+        ]
+        for script_file in script_files:
+            self._write_script(script_file, script_file)
+
+        with patch(
+            "src.IntuneCD.update.Intune.ProactiveRemediation.os.listdir",
+            return_value=script_files,
+        ):
+            detection_script, remediation_script = self.module._get_script_data(
+                "Policy A.yaml"
+            )
+
+        self.assertEqual(detection_script, "Policy A_detectionScript.ps1")
+        self.assertEqual(remediation_script, "Policy A_remediationScript.ps1")
+
+    def test_get_script_data_matches_id_with_append_id(self):
+        """Test that scripts are matched by id when filenames have appended ids."""
+        script_files = [
+            "Policy A_detectionScript__policy-a-id.ps1",
+            "Policy A_remediationScript__policy-a-id.ps1",
+            "Policy B_detectionScript__policy-b-id.ps1",
+            "Policy B_remediationScript__policy-b-id.ps1",
+        ]
+        for script_file in script_files:
+            self._write_script(script_file, script_file)
+
+        with patch(
+            "src.IntuneCD.update.Intune.ProactiveRemediation.os.listdir",
+            return_value=script_files,
+        ):
+            detection_script, remediation_script = self.module._get_script_data(
+                "Policy A__policy-a-id.yaml"
+            )
+
+        self.assertEqual(detection_script, "Policy A_detectionScript__policy-a-id.ps1")
+        self.assertEqual(
+            remediation_script, "Policy A_remediationScript__policy-a-id.ps1"
+        )
+
+    def test_get_script_data_handles_double_underscore_without_append_id(self):
+        """Test that double underscores in policy names are not treated as ids."""
+        script_files = [
+            "Policy__A_detectionScript.ps1",
+            "Policy__A_remediationScript.ps1",
+            "Policy B_detectionScript__A.ps1",
+            "Policy B_remediationScript__A.ps1",
+        ]
+        for script_file in script_files:
+            self._write_script(script_file, script_file)
+
+        with patch(
+            "src.IntuneCD.update.Intune.ProactiveRemediation.os.listdir",
+            return_value=script_files,
+        ):
+            detection_script, remediation_script = self.module._get_script_data(
+                "Policy__A.yaml"
+            )
+
+        self.assertEqual(detection_script, "Policy__A_detectionScript.ps1")
+        self.assertEqual(remediation_script, "Policy__A_remediationScript.ps1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fix [#261](https://github.com/almenscorner/IntuneCD/issues/261)

- Fix proactive remediation script lookup when backup files do not include appended Intune IDs
- Match no-ID backups by the policy filename prefix instead of using an empty substring match
- Preserve appended-ID matching and cover display names containing double underscores

Made with codex gpt:5.5

## Tests
- .venv/bin/python -m unittest discover
- Result: 135 tests passed